### PR TITLE
Added DevMgr::getNextDeviceName()

### DIFF
--- a/framework/include/DevMgr.hpp
+++ b/framework/include/DevMgr.hpp
@@ -57,7 +57,7 @@ public:
 
 	int ioctl(unsigned long cmd, void *arg);
 	ssize_t read(void *buf, size_t len);
-	ssize_t write(void *buf, size_t len);
+	ssize_t write(const void *buf, size_t len);
 
 private:
 	friend DevMgr;

--- a/framework/include/DevMgr.hpp
+++ b/framework/include/DevMgr.hpp
@@ -36,6 +36,7 @@
 #include <stdint.h>
 #include <time.h>
 #include <list>
+#include <string>
 
 #pragma once
 
@@ -101,6 +102,8 @@ public:
 	static int waitForUpdate(UpdateList &in_set, UpdateList &out_set, unsigned int timeout_ms);
 
 	static void setDevHandleError(DevHandle &h, int error);
+
+	static int getNextDeviceName(unsigned int &index, std::string &devname);
 private:
 	friend Framework;
 

--- a/framework/include/DevObj.hpp
+++ b/framework/include/DevObj.hpp
@@ -128,7 +128,7 @@ public:
 
         virtual ssize_t devRead(void *buf, size_t count);
 
-        virtual ssize_t devWrite(void *buf, size_t count);
+        virtual ssize_t devWrite(const void *buf, size_t count);
 
 	void updateNotify();
 

--- a/framework/src/DevMgr.cpp
+++ b/framework/src/DevMgr.cpp
@@ -374,7 +374,7 @@ ssize_t DevHandle::read(void *buf, size_t len)
 	}
 	return -1;
 }
-ssize_t DevHandle::write(void *buf, size_t len)
+ssize_t DevHandle::write(const void *buf, size_t len)
 {
 	if (m_handle) {
 		return reinterpret_cast<DevObj *>(m_handle)->devWrite(buf, len);

--- a/framework/src/DevMgr.cpp
+++ b/framework/src/DevMgr.cpp
@@ -275,6 +275,28 @@ void DevMgr::setDevHandleError(DevHandle &h, int error)
 	h.m_errno = error;
 }
 
+int DevMgr::getNextDeviceName(unsigned int &index, std::string &devname)
+{
+	if (g_driver_list == nullptr) {
+		return -1;
+	}
+	unsigned int i = 0;
+	int ret = -1;
+	g_lock->lock();
+	std::list<DriverFramework::DevObj *>::iterator it = g_driver_list->begin(); 
+	while (it != g_driver_list->end()) {
+		if (i == index) {
+			devname = (*it)->m_dev_path;
+			index+=1;
+			ret = 0;
+			break;
+		}
+		++it;
+	}
+	g_lock->unlock();
+	return ret;
+}
+
 int DevMgr::waitForUpdate(UpdateList &in_set, UpdateList &out_set, unsigned int timeout_ms)
 {
 	WaitList wl(in_set, out_set);

--- a/framework/src/DevObj.cpp
+++ b/framework/src/DevObj.cpp
@@ -41,7 +41,6 @@ using namespace DriverFramework;
 DevObj::DevObj(const char *name, const char *dev_path, const char *dev_class_path, DeviceBusType bus_type, unsigned int sample_interval_usecs) :
 	m_name(name),
 	m_dev_path(dev_path),
-	m_dev_class_path(dev_class_path),
 	m_sample_interval_usecs(sample_interval_usecs),
 	m_pub_blocked(false),
 	m_driver_instance(-1),
@@ -50,6 +49,11 @@ DevObj::DevObj(const char *name, const char *dev_path, const char *dev_class_pat
 	m_id.dev_id_s.bus = 0;
 	m_id.dev_id_s.address = 0;
 	m_id.dev_id_s.devtype = bus_type;
+
+	// dev_class_path might be nullptr
+	if (dev_class_path) {
+		m_dev_class_path.assign(dev_class_path);
+	}
 }
 
 int DevObj::init(void)

--- a/framework/src/DevObj.cpp
+++ b/framework/src/DevObj.cpp
@@ -149,7 +149,7 @@ ssize_t DevObj::devRead(void *buf, size_t count)
 	return -1;
 }
 
-ssize_t DevObj::devWrite(void *buf, size_t count)
+ssize_t DevObj::devWrite(const void *buf, size_t count)
 {
 	return -1;
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -146,7 +146,7 @@ int main()
 		while (DevMgr::getNextDeviceName(index, devname) == 0) {
 			DF_LOG_INFO("    %s", devname.c_str());
 		}
-		
+
 
 	}
 	DF_LOG_INFO("tests done");

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -140,6 +140,14 @@ int main()
 		DF_LOG_INFO("reading");
 		test_read(h, h2, 1000, true);
 
+		unsigned int index = 0;
+		std::string devname;
+		DF_LOG_INFO("Devices:");
+		while (DevMgr::getNextDeviceName(index, devname) == 0) {
+			DF_LOG_INFO("    %s", devname.c_str());
+		}
+		
+
 	}
 	DF_LOG_INFO("tests done");
 	test.stop();


### PR DESCRIPTION
This method provides a way to iterate through the list of devices.
The dev name is returned vs the dev class instance name:

/dev/accelsim vs /dev/accel0

Signed-off-by: Mark Charlebois <charlebm@gmail.com>