### PR TITLE
DFList: Remove extraneous mutex unlock

### DIFF
--- a/framework/src/DFList.cpp
+++ b/framework/src/DFList.cpp
@@ -201,7 +201,6 @@ void DFPointerList::deleteNode(Index node)
 		delete(node->m_next);
 	}
 	delete(node);
-	m_sync.unlock();
 }
 
 DFUIntList::DFUIListNode::DFUIListNode(unsigned int item) :


### PR DESCRIPTION
The `deleteNode` method is private and has a comment saying it needs
no internal locking and yet it had an call to `unlock`. This `unlock`
was causing `pthread_mutex_unlock` to be called on the same mutex
twice which according to the pthread docs invokes undefined behaviour,
in this case a SIGSEGV.