### PR TITLE
MPU9250: gyro scale was wrong by factor 2

### DIFF
--- a/drivers/mpu9250/MPU9250.hpp
+++ b/drivers/mpu9250/MPU9250.hpp
@@ -39,13 +39,13 @@
 namespace DriverFramework {
 
 // TODO: use define from some include for this
-#define PI_HALF_F	1.57079632679489661923f
+#define	M_PI		3.14159265358979323846	/* pi */
 
 // update frequency 250 Hz
 #define MPU9250_MEASURE_INTERVAL_US 4000
 
-// max 2000 degrees/s, 16 bit register, deg to rad conversion
-#define GYRO_RAW_TO_RAD_S 	 (2000.0f / 32768.0f * PI_HALF_F / 180.0f)
+// -2000 to 2000 degrees/s, 16 bit signed register, deg to rad conversion
+#define GYRO_RAW_TO_RAD_S 	 (2000.0f / 32768.0f * M_PI / 180.0f)
 
 
 class MPU9250 : public ImuSensor


### PR DESCRIPTION
This matches https://github.com/PX4/Firmware/blob/master/src/drivers/mpu9250/mpu9250.cpp#L461.