### PR TITLE
Workaround cleanup

### DIFF
--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -470,18 +470,10 @@ void HRTWorkQueue::unscheduleWorkItem(WorkHandle &wh)
 			DF_LOG_DEBUG("HRTWorkQueue::unscheduleWorkItem - invalid index");
 		}
 		else {
-#ifndef __QURT
-// XXX this is to revive the baro simulation for non-flying platforms
-// most likely this is not the correct fix,
-// and the root cause needs to be fixed
 			if (item->m_in_use == false) {
-#endif
 				DF_LOG_DEBUG("HRTWorkQueue::unscheduleWorkItem - 2");
 				idx = m_work_list.erase(idx);
-#ifndef __QURT
-				break;
 			}
-#endif
 		}
 		idx = m_work_list.next(idx);
 	}


### PR DESCRIPTION
This removes two workarounds:

- The one for pthread_cont_timedwait which was needed on Snapdragon, see #28.
- The one added after https://github.com/PX4/DriverFramework/commit/e62faaccae8775fd4dc237d4c43fb29a62603014, see #39.