### PR TITLE
WorkMgr bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DriverFramework
 
-Driver framework for POSIX based userspace drivers. 
+Driver framework for POSIX based userspace drivers.
 
 ## Overview
 
@@ -17,7 +17,7 @@ The main classes are:
 	* WorkMgr: Used by drivers to:
 		- schedule periodic tasks
 		- create and destroy WorkHandles
- 
+
 	* DevObj: The base class of all drivers
 
 The framework provides two intermediate driver classes as a base for new drivers:
@@ -41,13 +41,13 @@ If the exit condition is an async event and you need to block the calling thread
 ```
 DriverFramework::waitForShutdown();
 ```
-This will block until DriverFramework::shutdown() is called from another thread; 
+This will block until DriverFramework::shutdown() is called from another thread;
 
 
 ### Driver Initialization
 
 When the driver is initialized, it will register with the framework and provide an instance
-the base class path. 
+the base class path.
 
 For instance, if the driver was created with:
 
@@ -131,3 +131,12 @@ if (ret < 0) {
 ```
 Errors can be checked by testing for errors after a
 
+
+### Testing
+
+To run the unit tests build it and run the test app:
+
+```
+make
+build_linux/test/df_testapp
+```

--- a/framework/include/WorkMgr.hpp
+++ b/framework/include/WorkMgr.hpp
@@ -1,24 +1,24 @@
 /**********************************************************************
 * Copyright (c) 2015 Mark Charlebois
-* 
+*
 * All rights reserved.
-* 
+*
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted (subject to the limitations in the
 * disclaimer below) provided that the following conditions are met:
-* 
+*
 *  * Redistributions of source code must retain the above copyright
 *    notice, this list of conditions and the following disclaimer.
-* 
+*
 *  * Redistributions in binary form must reproduce the above copyright
 *    notice, this list of conditions and the following disclaimer in the
 *    documentation and/or other materials provided with the
 *    distribution.
-* 
+*
 *  * Neither the name of Dronecode Project nor the names of its
 *    contributors may be used to endorse or promote products derived
 *    from this software without specific prior written permission.
-* 
+*
 * NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
 * GRANTED BY THIS LICENSE.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
 * HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED

--- a/framework/include/WorkMgr.hpp
+++ b/framework/include/WorkMgr.hpp
@@ -81,7 +81,7 @@ public:
 private:
 	friend class Framework;
 
-	static bool isValid(const WorkHandle &h);
+	static bool isValidHandle(const WorkHandle &h);
 	static int initialize(void);
 	static void finalize(void);
 };

--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -711,11 +711,8 @@ int WorkMgr::releaseWorkHandle(WorkHandle &wh)
 	if (isValidHandle(wh)) {
 		WorkItem *item;
 		g_work_items->getAt(wh.m_handle, &item);
-		if (item->m_in_use) {
-			item->m_in_use = false;
-			HRTWorkQueue::instance()->unscheduleWorkItem(wh);
-			wh.m_handle = -1;
-		}
+		HRTWorkQueue::instance()->unscheduleWorkItem(wh);
+		wh.m_handle = -1;
 		wh.m_errno = 0;
 	}
 	else {

--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -453,18 +453,23 @@ void HRTWorkQueue::unscheduleWorkItem(WorkHandle &wh)
 	DFUIntList::Index idx = nullptr;
 	idx = m_work_list.next(idx);
 	while (idx != nullptr) {
-		unsigned int index;
-		m_work_list.get(idx, index);
+		// If we find it in the list at the current idx, let's go ahead and delete it.
+		unsigned index;
+		if (m_work_list.get(idx, index)) {
 
-		// remove unscheduled item
-		WorkItem *item;
-		if (!g_work_items->getAt(index, &item)) {
-			DF_LOG_DEBUG("HRTWorkQueue::unscheduleWorkItem - invalid index");
-		}
-		else {
-			if (item->m_in_use == false) {
-				DF_LOG_DEBUG("HRTWorkQueue::unscheduleWorkItem - 2");
-				idx = m_work_list.erase(idx);
+			if (index == (unsigned)wh.m_handle) {
+				// remove unscheduled item
+				WorkItem *item;
+				if (!g_work_items->getAt(index, &item)) {
+					DF_LOG_ERR("HRTWorkQueue::unscheduleWorkItem - invalid index");
+				}
+				else {
+					DF_LOG_DEBUG("HRTWorkQueue::unscheduleWorkItem - 2");
+					item->m_in_use = false;
+					idx = m_work_list.erase(idx);
+					// We're only unscheduling one item, so we can bail out here.
+					break;
+				}
 			}
 		}
 		idx = m_work_list.next(idx);

--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -748,7 +748,7 @@ int WorkMgr::schedule(WorkHandle &wh)
 				ret = -3;
 			}
 			else {
-				DF_LOG_INFO("WorkMgr::schedule - do schedule");
+				DF_LOG_DEBUG("WorkMgr::schedule - do schedule");
 				HRTWorkQueue::instance()->scheduleWorkItem(wh);
 			}
 		} else {

--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -73,7 +73,7 @@ public:
 		m_arg = arg;
 		m_queue_time = 0;
 		m_callback = callback;
-		m_delay_usec =delay_usec;
+		m_delay_usec = delay_usec;
 		m_in_use = false;
 
 		resetStats();

--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -179,7 +179,8 @@ static SyncObj *g_lock = nullptr;
 // Static Functions
 //-----------------------------------------------------------------------
 
-bool WorkMgr::isValid(const WorkHandle &h)
+// TODO FIXME: this seems conflicting with WorkHandle::isValid()
+bool WorkMgr::isValidHandle(const WorkHandle &h)
 {
 	return ((h.m_handle >=0) && ((unsigned int)h.m_handle < g_work_items->size()));
 }
@@ -639,7 +640,7 @@ void WorkMgr::getWorkHandle(WorkCallback cb, void *arg, uint32_t delay_usec, Wor
 	g_lock->lock();
 
 	// unschedule work and erase the handle if handle exists
-	if (isValid(wh)) {
+	if (isValidHandle(wh)) {
 		WorkItem *item;
 		g_work_items->getAt(wh.m_handle, &item);
 		if (item->m_in_use) {
@@ -665,13 +666,13 @@ void WorkMgr::getWorkHandle(WorkCallback cb, void *arg, uint32_t delay_usec, Wor
 		}
 
 		// If no free WorkItems, add one to the end
-		if (!isValid(wh)) {
+		if (!isValidHandle(wh)) {
 			g_work_items->pushBack(new WorkItem());
 			wh.m_handle = g_work_items->size()-1;
 		}
 	}
 
-	if (isValid(wh)) {
+	if (isValidHandle(wh)) {
 
 		// Re-use the WorkItem
 		WorkItem *item;
@@ -699,7 +700,7 @@ int WorkMgr::releaseWorkHandle(WorkHandle &wh)
 
 	int ret = 0;
 	g_lock->lock();
-	if (isValid(wh)) {
+	if (isValidHandle(wh)) {
 		WorkItem *item;
 		g_work_items->getAt(wh.m_handle, &item);
 		if (item->m_in_use) {
@@ -733,7 +734,7 @@ int WorkMgr::schedule(WorkHandle &wh)
 	DF_LOG_DEBUG("WorkMgr::schedule - checks ok");
 	int ret = 0;
 	g_lock->lock();
-	if (isValid(wh)) {
+	if (isValidHandle(wh)) {
 		WorkItem *item;
 		g_work_items->getAt(wh.m_handle, &item);
 		if (item->m_in_use) {

--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -647,10 +647,13 @@ void WorkMgr::getWorkHandle(WorkCallback cb, void *arg, uint32_t delay_usec, Wor
 	// unschedule work and erase the handle if handle exists
 	if (isValidHandle(wh)) {
 		WorkItem *item;
-		g_work_items->getAt(wh.m_handle, &item);
-		if (item->m_in_use) {
-			DF_LOG_DEBUG("Unscheduled work (%p) (%u)", item, item->m_delay_usec);
-			HRTWorkQueue::instance()->unscheduleWorkItem(wh);
+		if (g_work_items->getAt(wh.m_handle, &item)) {
+			if (item->m_in_use) {
+				DF_LOG_DEBUG("Unscheduled work (%p) (%u)", item, item->m_delay_usec);
+				HRTWorkQueue::instance()->unscheduleWorkItem(wh);
+			}
+		} else {
+			DF_LOG_ERR("Could not unschedule work, couldn't match handle");
 		}
 	}
 	else {

--- a/test/framework/WorkMgrTest.cpp
+++ b/test/framework/WorkMgrTest.cpp
@@ -99,7 +99,10 @@ bool WorkMgrTest::verifySchedule()
 	}
 	for (uint32_t i=10; i<300010; i+=10000) {
 		delay_usec=i;
-		WorkMgr::releaseWorkHandle(h);
+		int ret = WorkMgr::releaseWorkHandle(h);
+		if (ret != 0) {
+			DF_LOG_ERR("releaseWorkHandle failed with ret %d", ret);
+		}
 		WorkMgr::getWorkHandle(callback, &arg, delay_usec, h);
 		if (!h.isValid()) {
 			DF_LOG_ERR("getWorkHandle failed for delay of %u", delay_usec);

--- a/test/framework/WorkMgrTest.cpp
+++ b/test/framework/WorkMgrTest.cpp
@@ -65,9 +65,11 @@ static bool verifyDelay(WorkHandle &h, uint32_t delay_usec, int *arg)
 		now = offsetTime(); // In usec
 		elapsedtime = now - starttime;
 
-		// Shouldn't make more than extra 10us
-		if (elapsedtime > ((uint64_t)delay_usec*3+50)) {
-			DF_LOG_ERR("Failed %uusec timeout * 3 (%" PRIu64 ")", delay_usec, elapsedtime);
+		// Shouldn't take more than extra 50us
+		uint64_t time_to_achieve = delay_usec*3 + 50;
+		if (elapsedtime > time_to_achieve) {
+			DF_LOG_ERR("Failed %u usec timeout * 3 (%" PRIu64 " > %" PRIu64 ")",
+				   delay_usec, elapsedtime, time_to_achieve);
 			return false;
 		}
 	}


### PR DESCRIPTION
Since the recent fix https://github.com/PX4/DriverFramework/commit/e62faaccae8775fd4dc237d4c43fb29a62603014 broke SITL (see #39) more debugging was needed.

The main bug was that every call to ```getWorkHandle()``` removed the 0th entry in ```g_work_items``` instead of the respective one.

The current state is tested in SITL as well as on the Snapdragon.

@mcharleb I'd appreciate it if you could review this PR.