### PR TITLE
Device ids

### DIFF
--- a/drivers/bmp280/BMP280.cpp
+++ b/drivers/bmp280/BMP280.cpp
@@ -128,7 +128,6 @@ int BMP280::loadCalibration()
 
 int BMP280::bmp280_init()
 {
-
 	/* Zero the struct */
 	m_synchronize.lock();
 

--- a/drivers/bmp280/BMP280.hpp
+++ b/drivers/bmp280/BMP280.hpp
@@ -59,19 +59,27 @@ struct bmp280_sensor_calibration {
 // update frequency is 50 Hz (44.4-51.3Hz ) at 8x oversampling
 #define BMP280_MEASURE_INTERVAL_US 20000
 
-#define BMP280_SLAVE_ADDRESS 0b1110110       /* 7-bit slave address */
 #define BMP280_BUS_FREQUENCY_IN_KHZ 400
 #define BMP280_TRANSFER_TIMEOUT_IN_USECS 9000
 
 #define BMP280_MAX_LEN_SENSOR_DATA_BUFFER_IN_BYTES 6
 #define BMP280_MAX_LEN_CALIB_VALUES 26
 
+// TODO: include some common header file (currently in drv_sensor.h).
+#define DRV_DF_DEVTYPE_BMP280 0x42
+
+#define BMP280_SLAVE_ADDRESS 0b1110110       /* 7-bit slave address */
+
+
 class BMP280 : public BaroSensor
 {
 public:
 	BMP280(const char *device_path) :
 		BaroSensor(device_path, BMP280_MEASURE_INTERVAL_US)
-	{}
+	{
+		m_id.dev_id_s.devtype = DRV_DF_DEVTYPE_BMP280;
+		m_id.dev_id_s.address = BMP280_SLAVE_ADDRESS;
+	}
 
 	// @return 0 on success, -errno on failure
 	virtual int start();

--- a/drivers/hmc5883/HMC5883.cpp
+++ b/drivers/hmc5883/HMC5883.cpp
@@ -38,7 +38,6 @@
 #include "dev_fs_lib_i2c.h"
 #endif
 
-#define HMC5883_SLAVE_ADDRESS		(0x1e)
 // TODO: go to 400 eventually
 #define HMC5883_BUS_FREQUENCY_IN_KHZ	(100)
 // TODO: no idea what to use here

--- a/drivers/hmc5883/HMC5883.hpp
+++ b/drivers/hmc5883/HMC5883.hpp
@@ -43,6 +43,11 @@ namespace DriverFramework
 // 150 Hz (supported in single measurment mode is up to 160 Hz
 #define HMC5883_MEASURE_INTERVAL_US (1000000/150)
 
+// TODO: include some common header file (currently in drv_sensor.h).
+#define DRV_DF_DEVTYPE_HMC5883 0x43
+
+#define HMC5883_SLAVE_ADDRESS		(0x1e)
+
 
 class HMC5883 : public MagSensor
 {
@@ -50,7 +55,10 @@ public:
 	HMC5883(const char *device_path) :
 		MagSensor(device_path, HMC5883_MEASURE_INTERVAL_US),
 		_measurement_requested(false)
-	{}
+	{
+		m_id.dev_id_s.devtype = DRV_DF_DEVTYPE_HMC5883;
+		m_id.dev_id_s.address = HMC5883_SLAVE_ADDRESS;
+	}
 
 	// @return 0 on success, -errno on failure
 	virtual int start();

--- a/drivers/mpu9250/MPU9250.cpp
+++ b/drivers/mpu9250/MPU9250.cpp
@@ -36,6 +36,7 @@
 #include "DriverFramework.hpp"
 #include "MPU9250.hpp"
 
+
 #define MPUREG_WHOAMI			0x75
 #define MPUREG_SMPLRT_DIV		0x19
 #define MPUREG_CONFIG			0x1A
@@ -131,8 +132,6 @@
 #define BIT_RAW_RDY_EN			0x01
 #define BIT_INT_ANYRD_2CLEAR		0x10
 
-#define MPU_WHOAMI_9250			0x71
-
 #define MPU9250_ONE_G					9.80665f
 
 
@@ -141,7 +140,6 @@ using namespace DriverFramework;
 
 int MPU9250::mpu9250_init()
 {
-
 	/* Zero the struct */
 	m_synchronize.lock();
 	m_sensor_data.accel_m_s2_x = 0.0f;

--- a/drivers/mpu9250/MPU9250.hpp
+++ b/drivers/mpu9250/MPU9250.hpp
@@ -48,13 +48,22 @@ namespace DriverFramework
 // -2000 to 2000 degrees/s, 16 bit signed register, deg to rad conversion
 #define GYRO_RAW_TO_RAD_S 	 (2000.0f / 32768.0f * M_PI / 180.0f)
 
+// TODO: include some common header file (currently in drv_sensor.h).
+#define DRV_DF_DEVTYPE_MPU9250 0x41
+
+#define MPU_WHOAMI_9250			0x71
+
 
 class MPU9250 : public ImuSensor
 {
 public:
 	MPU9250(const char *device_path) :
 		ImuSensor(device_path, MPU9250_MEASURE_INTERVAL_US)
-	{}
+	{
+		m_id.dev_id_s.devtype = DRV_DF_DEVTYPE_MPU9250;
+		// TODO: does the WHOAMI make sense as an address?
+		m_id.dev_id_s.address = MPU_WHOAMI_9250;
+	}
 
 	// @return 0 on success, -errno on failure
 	virtual int start();

--- a/framework/include/I2CDevObj.hpp
+++ b/framework/include/I2CDevObj.hpp
@@ -58,7 +58,9 @@ class I2CDevObj : public DevObj
 public:
 	I2CDevObj(const char *name, const char *dev_path, const char *dev_class_path, unsigned int sample_interval_usec) :
 		DevObj(name, dev_path, dev_class_path, DeviceBusType_I2C, sample_interval_usec)
-	{}
+	{
+		m_id.dev_id_s.bus = DeviceBusType_I2C;
+	}
 
 	virtual ~I2CDevObj();
 

--- a/framework/include/SPIDevObj.hpp
+++ b/framework/include/SPIDevObj.hpp
@@ -67,7 +67,9 @@ public:
 
 	SPIDevObj(const char *name, const char *dev_path, const char *dev_class_path, unsigned int sample_interval_usec) :
 		DevObj(name, dev_path, dev_class_path, DeviceBusType_SPI, sample_interval_usec)
-	{}
+	{
+		m_id.dev_id_s.bus = DeviceBusType_SPI;
+	}
 
 	virtual ~SPIDevObj();
 


### PR DESCRIPTION
This brings proper support for the device id for MPU9250, BMP280, and HMC5883.