### PR TITLE
framework: raise stacksize of worker thread

### DIFF
--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -432,7 +432,7 @@ int HRTWorkQueue::initialize(void)
 	const size_t stacksize = 2048;
 
 	if (pthread_attr_setstacksize(&attr, stacksize) != 0) {
-		DF_LOG_ERR("failed to set stack size of %d bytes", stacksize);
+		DF_LOG_ERR("failed to set stack size of %lu bytes", stacksize);
 		return -5;
 	}
 #endif

--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -426,14 +426,16 @@ int HRTWorkQueue::initialize(void)
 
 	DF_LOG_DEBUG("setRealtimeSched success");
 
+#ifdef __PX4_QURT
 	// Try to set a stack size. This stack size is later used in _measure() calls
-	// in the sensor drivers.
+	// in the sensor drivers, at least on QURT.
 	const size_t stacksize = 2048;
 
 	if (pthread_attr_setstacksize(&attr, stacksize) != 0) {
 		DF_LOG_ERR("failed to set stack size of %d bytes", stacksize);
 		return -5;
 	}
+#endif
 
 	// Create high priority worker thread
 	if (pthread_create(&g_tid, &attr, process_trampoline, NULL)) {

--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -435,6 +435,7 @@ int HRTWorkQueue::initialize(void)
 		DF_LOG_ERR("failed to set stack size of %lu bytes", stacksize);
 		return -5;
 	}
+
 #endif
 
 	// Create high priority worker thread

--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -426,9 +426,18 @@ int HRTWorkQueue::initialize(void)
 
 	DF_LOG_DEBUG("setRealtimeSched success");
 
+	// Try to set a stack size. This stack size is later used in _measure() calls
+	// in the sensor drivers.
+	const size_t stacksize = 2048;
+
+	if (pthread_attr_setstacksize(&attr, stacksize) != 0) {
+		DF_LOG_ERR("failed to set stack size of %d bytes", stacksize);
+		return -5;
+	}
+
 	// Create high priority worker thread
 	if (pthread_create(&g_tid, &attr, process_trampoline, NULL)) {
-		return -5;
+		return -6;
 	}
 
 	DF_LOG_DEBUG("pthread_create success");


### PR DESCRIPTION
The worker thread needs more stacksize, otherwise the _measure() call crashes once the delta angles are added in the MPU9250.

Tested on Snapdragon and SITL.