### PR TITLE
MPU9250: lower sample rate from 1kHz to 500Hz

### DIFF
--- a/drivers/mpu9250/MPU9250.hpp
+++ b/drivers/mpu9250/MPU9250.hpp
@@ -42,8 +42,8 @@ namespace DriverFramework
 // TODO: use define from some include for this
 #define	M_PI		3.14159265358979323846	/* pi */
 
-// update frequency 1000 Hz
-#define MPU9250_MEASURE_INTERVAL_US 1000
+// update frequency 500 Hz
+#define MPU9250_MEASURE_INTERVAL_US 2000
 
 // -2000 to 2000 degrees/s, 16 bit signed register, deg to rad conversion
 #define GYRO_RAW_TO_RAD_S 	 (2000.0f / 32768.0f * M_PI / 180.0f)


### PR DESCRIPTION
This is needed to lower the risk of running into a pthread_cond_timedwait timeout.

It is related to #48 and #49.