### PR TITLE
framework: use CLOCK_MONOTONIC on Snapdragon Linux

### DIFF
--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -206,7 +206,13 @@ uint64_t DriverFramework::offsetTime(void)
 {
 	struct timespec ts = {};
 
+#ifdef __PX4_POSIX_EAGLE
+	// Snapdragon Linux side: If the  CLOCK_MONOTONIC is used for
+	// pthread_cond_timedwait it returns immediately and doesn't work.
+	(void)clockGetRealtime(&ts);
+#else
 	(void)clockGetMonotonic(&ts);
+#endif
 
 	pthread_mutex_lock(&g_timestart_lock);
 


### PR DESCRIPTION
If CLOCK_MONOTONIC is used, pthread_cond_timedwait returns immediately
leading to 100% CPU use.

Tested on Snapdragon. This brings the CPU load down from ~ 150% of one CPU to ~ 50%.

FYI @liamstask 