### PR TITLE
framework: use monotonic clock for scheduling

### DIFF
--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -444,7 +444,7 @@ int HRTWorkQueue::initialize(void)
 
 	DF_LOG_DEBUG("setRealtimeSched success");
 
-#ifdef __PX4_QURT
+#ifdef __QURT
 	// Try to set a stack size. This stack size is later used in _measure() calls
 	// in the sensor drivers, at least on QURT.
 	const size_t stacksize = 2048;
@@ -630,7 +630,7 @@ void HRTWorkQueue::process(void)
 		// pthread_cond_timedwait uses absolute time
 		ts = offsetTimeToAbsoluteTime(now + next);
 
-#ifdef __PX4_QURT
+#ifdef __QURT
 		uint64_t now_later = offsetTime();
 		int64_t diff = (int64_t)(now + next) - (int64_t)now_later;
 
@@ -640,7 +640,7 @@ void HRTWorkQueue::process(void)
 			DF_LOG_DEBUG("HRTWorkQueue::process waiting for work (%" PRIi64 ")", diff);
 			// Wait until next expiry or until a new item is rescheduled
 			pthread_cond_timedwait(&g_reschedule_cond, &g_hrt_lock, &ts);
-#ifdef __PX4_QURT
+#ifdef __QURT
 		}
 
 #endif

--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -418,8 +418,9 @@ int HRTWorkQueue::initialize(void)
 
 	DF_LOG_DEBUG("pthread_mutex_init success");
 
-#ifndef __PX4_QURT
+#if !defined(__QURT) && !(defined(__APPLE__) && defined(__MACH__))
 	// QURT supposedly always uses CLOCK_MONOTONIC.
+	// Also CLOCK_MONOTONIC is not available on Mac.
 	pthread_condattr_t condattr;
 	pthread_condattr_init(&condattr);
 


### PR DESCRIPTION
The pthread_cond_timedwait can be configured to use the monotonic clock,
at least on the Linux side on the Snapdragon. This is the proper fix for
the pthread_cond_timedwait that kept returning immediately. Switching to
CLOCK_REALTIME was only a workaround.