### PR TITLE
Update cmake_hexagon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,14 @@
 all: linux qurt rpi2
 
-.PHONY update:
-update:
-	git submodule update --init --recursive
-
 define df_cmake_generate
 mkdir -p build_$(1) && cd build_$(1) && cmake .. -DDF_TARGET=$(1) -DCMAKE_TOOLCHAIN_FILE=$(2) -DDF_ENABLE_TESTS=1
 endef
 
-rpi2 linux nuttx: update
+rpi2 linux nuttx:
 	$(call df_cmake_generate,$@,cmake/toolchains/Toolchain-$@.cmake)
 	cd build_$@ && make
 
-qurt: update
+qurt:
 	$(call df_cmake_generate,qurt,cmake/cmake_hexagon/toolchain/Toolchain-qurt.cmake)
 	cd build_qurt && make
 


### PR DESCRIPTION
This updates the cmake_hexagon submodule which resolves a compile error.

Also, the git submodule magic triggered in the Makefile is removed.