### PR TITLE
Simpler integration

### DIFF
--- a/drivers/mpu9250/MPU9250.cpp
+++ b/drivers/mpu9250/MPU9250.cpp
@@ -176,7 +176,7 @@ int MPU9250::mpu9250_init()
 	m_sensor_data.gyro_range_hit_counter = 0;
 	m_sensor_data.accel_range_hit_counter = 0;
 
-	m_sensor_data.time_offset_us = 0;
+	m_sensor_data.is_last_fifo_sample = false;
 
 	m_synchronize.unlock();
 
@@ -549,11 +549,10 @@ void MPU9250::_measure()
 		m_sensor_data.gyro_rad_s_y = float(report->gyro_y) * GYRO_RAW_TO_RAD_S;
 		m_sensor_data.gyro_rad_s_z = float(report->gyro_z) * GYRO_RAW_TO_RAD_S;
 
-		++m_sensor_data.read_counter;
+		// Flag if this is the last sample, and _publish() should wrap up the data it has received.
+		m_sensor_data.is_last_fifo_sample = ((i + 1) == (read_len / sizeof(fifo_packet)));
 
-		// A FIFO sample is created at 8kHz, which means the interval between samples is 125 us.
-		// The last read FIFO sample at i+1 has an offset of 0.
-		m_sensor_data.time_offset_us = -((read_len / sizeof(fifo_packet)) - (i + 1)) * 125;
+		++m_sensor_data.read_counter;
 
 		_publish(m_sensor_data);
 

--- a/drivers/mpu9250/MPU9250.cpp
+++ b/drivers/mpu9250/MPU9250.cpp
@@ -176,6 +176,7 @@ int MPU9250::mpu9250_init()
 	m_sensor_data.gyro_range_hit_counter = 0;
 	m_sensor_data.accel_range_hit_counter = 0;
 
+	m_sensor_data.fifo_sample_interval_us = 0;
 	m_sensor_data.is_last_fifo_sample = false;
 
 	m_synchronize.unlock();
@@ -548,6 +549,9 @@ void MPU9250::_measure()
 		m_sensor_data.gyro_rad_s_x = float(report->gyro_x) * GYRO_RAW_TO_RAD_S;
 		m_sensor_data.gyro_rad_s_y = float(report->gyro_y) * GYRO_RAW_TO_RAD_S;
 		m_sensor_data.gyro_rad_s_z = float(report->gyro_z) * GYRO_RAW_TO_RAD_S;
+
+		// Pass on the sampling interval between FIFO samples at 8kHz.
+		m_sensor_data.fifo_sample_interval_us = 125;
 
 		// Flag if this is the last sample, and _publish() should wrap up the data it has received.
 		m_sensor_data.is_last_fifo_sample = ((i + 1) == (read_len / sizeof(fifo_packet)));

--- a/framework/include/ImuSensor.hpp
+++ b/framework/include/ImuSensor.hpp
@@ -68,6 +68,7 @@ struct imu_sensor_data {
 	uint64_t	fifo_corruption_counter;
 	uint64_t	gyro_range_hit_counter;
 	uint64_t	accel_range_hit_counter;
+	unsigned	fifo_sample_interval_us;
 	bool		is_last_fifo_sample;
 };
 

--- a/framework/include/ImuSensor.hpp
+++ b/framework/include/ImuSensor.hpp
@@ -68,7 +68,7 @@ struct imu_sensor_data {
 	uint64_t	fifo_corruption_counter;
 	uint64_t	gyro_range_hit_counter;
 	uint64_t	accel_range_hit_counter;
-	int32_t		time_offset_us;
+	bool		is_last_fifo_sample;
 };
 
 class ImuSensor : public SPIDevObj


### PR DESCRIPTION
Instead of calculating time offsets between sampling, it's easier to just assume a constant FIFO sampling interval inside `_publish`. All `_publish` needs to know is if it receives the last FIFO sample and should therefore wrap up and publish.