### PR TITLE
HRTWorkQueue: avoid scheduling drift

### DIFF
--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -569,7 +569,6 @@ void HRTWorkQueue::process(void)
 	DF_LOG_DEBUG("HRTWorkQueue::process");
 	uint64_t next;
 	uint64_t elapsed;
-	uint64_t remaining;
 	timespec ts;
 	uint64_t now;
 

--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -590,7 +590,7 @@ void HRTWorkQueue::process(void)
 			m_work_list.get(idx, index);
 
 			if (index < g_work_items->size()) {
-				WorkItem *item;
+				WorkItem *item = nullptr;
 				g_work_items->getAt(index, &item);
 				now = offsetTime();
 				elapsed = now - item->m_queue_time;

--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -586,13 +586,13 @@ void HRTWorkQueue::process(void)
 
 		while ((!m_exit_requested) && (idx != nullptr)) {
 			DF_LOG_DEBUG("HRTWorkQueue::process work exists");
-			now = offsetTime();
 			unsigned int index;
 			m_work_list.get(idx, index);
 
 			if (index < g_work_items->size()) {
 				WorkItem *item = nullptr;
 				g_work_items->getAt(index, &item);
+				now = offsetTime();
 				elapsed = now - item->m_queue_time;
 				//DF_LOG_DEBUG("now = %lu elapsed = %lu delay = %luusec\n", now, elapsed, item.m_delay_usec);
 
@@ -602,7 +602,7 @@ void HRTWorkQueue::process(void)
 					item->updateStats(now);
 
 					// reschedule work
-					item->m_queue_time = offsetTime();
+					item->m_queue_time += item->m_delay_usec;
 					item->m_in_use = true;
 
 					void *tmpptr = item->m_arg;


### PR DESCRIPTION
This should fix #68.

It would also be a good idea to check if there's too much work & scheduling falls behind.

@LorenzMeier can you test if this improves things?

btw `make run` shows some failed tests, but the same happens on master (not reported as error in travis).