### PR TITLE
WIP: latency improvement

### DIFF
--- a/framework/src/DFList.cpp
+++ b/framework/src/DFList.cpp
@@ -71,7 +71,10 @@ DFPointerList::~DFPointerList()
 
 unsigned int DFPointerList::size()
 {
-	return m_size;
+	m_sync.lock();
+	unsigned int rv = m_size;
+	m_sync.unlock();
+	return rv;
 }
 
 bool DFPointerList::pushBack(void *item)


### PR DESCRIPTION
Disambiguated use of static g_lock in 2 files.
Added tuning parameter to compensate for latency of pthread_cond_timedwait.
Deadlines are now usually within 1-3usec (execpt for 0usec delay).

Also fixed thread lock race conditions found using clang and thread sanitizer.

This has only been tested on Linux. Not yet ready to merge.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>