### PR TITLE
WIP: Clock fixes (Do not merge)

### DIFF
--- a/framework/include/DriverFramework.hpp
+++ b/framework/include/DriverFramework.hpp
@@ -60,7 +60,7 @@ namespace DriverFramework
  *
  * @return 0 if successful, nonzero else
  */
-int clockGetRealtime(struct timespec *ts);
+int absoluteTime(struct timespec *ts);
 
 // convert offset time to absolute time
 struct timespec absoluteTimeInFuture(uint64_t time_ms);

--- a/framework/include/DriverFramework.hpp
+++ b/framework/include/DriverFramework.hpp
@@ -87,8 +87,6 @@ public:
 	// This function must be called before any of the functions below
 	static int initialize(void);
 
-	static int useClockMonotonic();
-
 	// Terminate the driver framework
 	static void shutdown(void);
 

--- a/framework/include/DriverFramework.hpp
+++ b/framework/include/DriverFramework.hpp
@@ -60,10 +60,10 @@ namespace DriverFramework
  *
  * @return 0 if successful, nonzero else
  */
-int absoluteTime(struct timespec *ts);
+int absoluteTime(struct timespec &ts);
 
 // convert offset time to absolute time
-struct timespec absoluteTimeInFuture(uint64_t time_ms);
+int absoluteTimeInFuture(uint64_t time_ms, struct timespec &ts);
 
 /**
  * Get the absolute time off the system monotonic clock
@@ -72,7 +72,7 @@ struct timespec absoluteTimeInFuture(uint64_t time_ms);
  *
  * @return 0 if successful, nonzero else
  */
-int clockGetMonotonic(struct timespec *ts);
+int clockGetMonotonic(struct timespec &ts);
 
 
 #ifdef DF_ENABLE_BACKTRACE
@@ -86,6 +86,8 @@ public:
 	// Initialize the driver framework
 	// This function must be called before any of the functions below
 	static int initialize(void);
+
+	static int useClockMonotonic();
 
 	// Terminate the driver framework
 	static void shutdown(void);

--- a/framework/src/DFList.cpp
+++ b/framework/src/DFList.cpp
@@ -71,7 +71,10 @@ DFPointerList::~DFPointerList()
 
 unsigned int DFPointerList::size()
 {
-	return m_size;
+	m_sync.lock();
+	unsigned int rv = m_size;
+	m_sync.unlock();
+	return rv;
 }
 
 bool DFPointerList::pushBack(void *item)

--- a/framework/src/Time.cpp
+++ b/framework/src/Time.cpp
@@ -64,11 +64,12 @@ using namespace DriverFramework;
 // Global Functions
 //-----------------------------------------------------------------------
 
-int DriverFramework::clockGetRealtime(struct timespec *ts)
+int DriverFramework::absoluteTime(struct timespec *ts)
 {
-	return clock_gettime(CLOCK_REALTIME, ts);
+	return clock_gettime(CLOCK_MONOTONIC, ts);
 }
 
+#if 0
 #ifdef __PX4_NUTTX
 #ifndef CLOCK_MONOTONIC
 #define CLOCK_MONOTONIC 1
@@ -84,12 +85,13 @@ int DriverFramework::clockGetMonotonic(struct timespec *ts)
 	return clock_gettime(CLOCK_MONOTONIC, ts);
 #endif
 }
+#endif
 
 timespec DriverFramework::absoluteTimeInFuture(uint64_t time_ms)
 {
 	struct timespec ts;
 
-	clockGetMonotonic(&ts);
+	(void)absoluteTime(&ts);
 
 	uint64_t nsecs = ts.tv_nsec + time_ms * 1000000;
 	uint64_t secs = (nsecs / 1000000000);

--- a/test/framework/SyncObjTest.cpp
+++ b/test/framework/SyncObjTest.cpp
@@ -46,25 +46,26 @@ void SyncObjTest::_doTests()
 	so.unlock();
 	reportResult("Simple lock/unlock", passed);
 
-#if 0
 	uint64_t now = offsetTime();
-	int rv = so.waitOnSignal(1);
+	unsigned long wait_in_ms = 1;
+	so.lock();
+	int rv = so.waitOnSignal(wait_in_ms);
+	so.unlock();
 	uint64_t after = offsetTime();
-	uint64_t delta = after - now;
+	uint64_t delta_usec = after - now;
 
 	if (rv != ETIMEDOUT) {
-		DF_LOG_INFO("waitSignal() did not return ETIMEDOUT");
+		DF_LOG_ERR("waitSignal() did not return ETIMEDOUT");
 		passed = false;
 	}
 
-	bool dtime_ok = (delta > 1000) && (delta < 1200);
+	bool dtime_ok = (delta_usec > wait_in_ms*1000) && (delta_usec < wait_in_ms*1200);
 
 	if (!dtime_ok) {
-		DF_LOG_INFO("waitSignal() timeout of 1ms was %" PRIu64 "us", delta);
+		DF_LOG_ERR("waitSignal() timeout of 1ms was %" PRIu64 "us", delta_usec);
 		passed = false;
 	}
 
 	reportResult("waitSignal() timeout", passed && dtime_ok);
-#endif
 }
 

--- a/test/framework/SyncObjTest.cpp
+++ b/test/framework/SyncObjTest.cpp
@@ -47,7 +47,7 @@ void SyncObjTest::_doTests()
 	reportResult("Simple lock/unlock", passed);
 
 	uint64_t now = offsetTime();
-	unsigned long wait_in_ms = 1;
+	unsigned long wait_in_ms = 5;
 	so.lock();
 	int rv = so.waitOnSignal(wait_in_ms);
 	so.unlock();
@@ -62,7 +62,7 @@ void SyncObjTest::_doTests()
 	bool dtime_ok = (delta_usec > wait_in_ms*1000) && (delta_usec < wait_in_ms*1200);
 
 	if (!dtime_ok) {
-		DF_LOG_ERR("waitSignal() timeout of 1ms was %" PRIu64 "us", delta_usec);
+		DF_LOG_ERR("waitSignal() timeout of %lums was %" PRIu64 "us", wait_in_ms, delta_usec);
 		passed = false;
 	}
 

--- a/test/framework/TimeTest.cpp
+++ b/test/framework/TimeTest.cpp
@@ -88,9 +88,8 @@ bool TimeTest::verifyAbsoluteTime()
 	int64_t msecs = delta.tv_sec * 1000 + delta.tv_nsec/1000000 - seconds * 1000;
 
 	// sleep should be accurate withing 50ms
-	DF_LOG_INFO("sleep(2) took %ldsec %ldms",seconds, msecs);
 	if (seconds != 2 || msecs > 50) {
-		DF_LOG_ERR("sleep(2) took %ldsec %ldms",seconds, msecs);
+		DF_LOG_ERR("sleep(2) took %" PRId64 "sec %" PRId64 "ms",seconds, msecs);
 		return false;
 	}
 	return true;
@@ -112,9 +111,8 @@ bool TimeTest::verifyAbsoluteTimeInFuture()
 	int64_t msecs = delta.tv_sec * 1000 + delta.tv_nsec/1000000 - seconds * 1000;
 
 	// sleep should be accurate withing 50ms
-	DF_LOG_INFO("sleep(2) took an extra %ldsec %ldms",seconds, msecs);
 	if (seconds != 0 || msecs > 50) {
-		DF_LOG_ERR("sleep(2) took an extra %ldsec %ldms",seconds, msecs);
+		DF_LOG_ERR("sleep(2) took an extra %" PRId64 "sec %" PRId64 "ms",seconds, msecs);
 		return false;
 	}
 	return true;

--- a/test/framework/TimeTest.cpp
+++ b/test/framework/TimeTest.cpp
@@ -68,7 +68,7 @@ bool TimeTest::verifyAbsoluteTime()
 {
 	struct timespec ts, ts2;
 
-	int rv = absoluteTime(&ts);
+	int rv = absoluteTime(ts);
 	if (rv) {
 		DF_LOG_ERR("absoluteTime failed (%d)",rv);
 		return false;
@@ -76,7 +76,7 @@ bool TimeTest::verifyAbsoluteTime()
 
 	sleep(2);
 
-	rv = absoluteTime(&ts2);
+	rv = absoluteTime(ts2);
 	if (rv) {
 		DF_LOG_ERR("absoluteTime failed (%d)",rv);
 		return false;
@@ -100,11 +100,11 @@ bool TimeTest::verifyAbsoluteTimeInFuture()
 {
 	struct timespec ts, ts2;
 
-	ts = absoluteTimeInFuture(2000);
+	(void)absoluteTimeInFuture(2000, ts);
 
 	sleep(2);
 
-	(void)absoluteTime(&ts2);
+	(void)absoluteTime(ts2);
 
 	struct timespec delta = { ts2.tv_sec - ts.tv_sec, ts2.tv_nsec - ts.tv_nsec };
 

--- a/test/framework/TimeTest.hpp
+++ b/test/framework/TimeTest.hpp
@@ -49,6 +49,8 @@ protected:
 
 private:
 	bool verifyOffsetTime(void);
+	bool verifyAbsoluteTime(void);
+	bool verifyAbsoluteTimeInFuture(void);
 };
 
 

--- a/test/framework/WorkMgrTest.cpp
+++ b/test/framework/WorkMgrTest.cpp
@@ -86,7 +86,7 @@ static bool verifyDelay(WorkHandle &h, uint32_t delay_usec, int *arg)
 		// Shouldn't take more than extra 50us
 		uint64_t time_to_achieve = delay_usec * (i+1) + 100;
 
-		DF_LOG_INFO("Delay: %uusec Expected: %lu Actual: %lu Delta: %ldusec",
+		DF_LOG_INFO("Delay: %uusec Expected: %" PRIu64 " Actual: %" PRIu64 " Delta: %ldusec",
 			delay_usec * (i+1), starttime + delay_usec * (i+1), cb_times[i],
 			(long)(cb_times[i]-starttime-(delay_usec * (i+1))));
 


### PR DESCRIPTION
The SyncObj unit test was disabled and that masked a but in DF. At some
point the clock was changed to CLOCK_MONOTONIC (except for Apple) but that breaks all
uses of pthread_cond_timedwait on Linux which MUST use CLOCK_REALTIME and on Linux
ideally DF would use CLOCK_REALTIME_RAW.

This PR is trying to resolve what happened to the clocks and to fix them
on Linux. The state on QuRT and NuttX is unknown.
