### PR TITLE
framework: fix build for RPI2

### DIFF
--- a/framework/include/DriverFramework.hpp
+++ b/framework/include/DriverFramework.hpp
@@ -45,7 +45,7 @@
 #include "WorkMgr.hpp"
 #endif
 
-#ifdef __DF_LINUX
+#if defined(__DF_LINUX) || defined(__RPI2)
 // Show backtrace on error
 #define DF_ENABLE_BACKTRACE 1
 #endif

--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -171,7 +171,7 @@ timespec DriverFramework::offsetTimeToAbsoluteTime(uint64_t offset_time)
 	return ts;
 }
 
-//#if DF_ENABLE_BACKTRACE
+#if DF_ENABLE_BACKTRACE
 void DriverFramework::backtrace()
 {
 	void *buffer[10];
@@ -190,7 +190,7 @@ void DriverFramework::backtrace()
 
 	free(callstack);
 }
-//#endif
+#endif
 
 //-----------------------------------------------------------------------
 // Class Methods


### PR DESCRIPTION
Not only native Linux build support backtracing on errors. That's why it
is logical to not to ignore it. Furthermore, without this patch the
build had yielded errors reporting missing backtrace() definition.