### PR TITLE
Swiched Nuttx build to use CLOCK_REALTIME

### DIFF
--- a/framework/src/SyncObj.cpp
+++ b/framework/src/SyncObj.cpp
@@ -51,8 +51,8 @@ SyncObj::SyncObj()
 	pthread_condattr_t condattr;
 	pthread_condattr_init(&condattr);
 
-// QURT always uses CLOCK_MONOTONIC.
-// CLOCK_MONOTONIC is not available on OSX.
+// CLOCK_MONOTONIC is not available on OSX and NuttX
+// CLOCK_MONOTONIC is the default on QuRT so it need not be explicitly set
 #if !defined(__QURT) && !(defined(__APPLE__) && defined(__MACH__)) && !defined(__DF_NUTTX)
 
 	// Configure the pthread_cond_timedwait to use the monotonic clock

--- a/framework/src/SyncObj.cpp
+++ b/framework/src/SyncObj.cpp
@@ -53,7 +53,7 @@ SyncObj::SyncObj()
 
 // QURT always uses CLOCK_MONOTONIC.
 // CLOCK_MONOTONIC is not available on OSX.
-#if !defined(__QURT) && !(defined(__APPLE__) && defined(__MACH__))
+#if !defined(__QURT) && !(defined(__APPLE__) && defined(__MACH__)) && !defined(__DF_NUTTX)
 
 	// Configure the pthread_cond_timedwait to use the monotonic clock
 	// because we don't want time skews to influence the scheduling.

--- a/framework/src/Time.cpp
+++ b/framework/src/Time.cpp
@@ -64,16 +64,11 @@ using namespace DriverFramework;
 // Global Functions
 //-----------------------------------------------------------------------
 
-#ifdef __PX4_NUTTX
-#ifndef CLOCK_MONOTONIC
-#define CLOCK_MONOTONIC 1
-#endif
-#endif
 int DriverFramework::absoluteTime(struct timespec &ts)
 {
-#if defined(__APPLE__) && defined(__MACH__)
+#if (defined(__APPLE__) && defined(__MACH__)) || defined(__DF_NUTTX)
 #define CLOCK_REALTIME 0
-	// CLOCK_MONOTONIC not available on Mac
+	// CLOCK_MONOTONIC not available on Mac or NuttX
 	return clock_gettime(CLOCK_REALTIME, &ts);
 #else
 	return clock_gettime(CLOCK_MONOTONIC, &ts);


### PR DESCRIPTION
NuttX doesn't seem to support CLOCK_MONOTONIC

pthread_cond_timewait in NuttX uses CLOCK_REALTIME

Signed-off-by: Mark Charlebois <charlebm@gmail.com>