### PR TITLE
trone: probe first and then start measure calls

### DIFF
--- a/drivers/trone/TROne.cpp
+++ b/drivers/trone/TROne.cpp
@@ -68,21 +68,32 @@ int TROne::start()
 		goto exit;
 	}
 
-	result = DevObj::start();
-
 	if (result != 0) {
 		DF_LOG_ERR("error: could not start DevObj");
 		goto exit;
 	}
 
-	// probe to check if device is reachable
+	/* Probe to check if device is available, otherwise give up. */
 	result = probe();
+
+	if (result != 0) {
+		DF_LOG_ERR("probing not successful");
+		goto exit;
+	}
+
+	result = DevObj::start();
+
+	if (result != 0) {
+		DF_LOG_ERR("DevObj start not successful");
+		DevObj::stop();
+		goto exit;
+
+	}
 
 exit:
 
 	if (result != 0) {
 		DF_LOG_ERR("error: Failed to start TROne");
-		DevObj::stop();
 		I2CDevObj::stop();
 		devClose();
 	}


### PR DESCRIPTION
If the scheduling is started before probe call, it seems to be busy
looping and blocking the HMC5883.

This fixes https://github.com/PX4/Firmware/issues/4639.