### PR TITLE
Fix SITL CPU

### DIFF
--- a/framework/include/DriverFramework.hpp
+++ b/framework/include/DriverFramework.hpp
@@ -63,7 +63,7 @@ namespace DriverFramework
 int absoluteTime(struct timespec &ts);
 
 // convert offset time to absolute time
-int absoluteTimeInFuture(uint64_t time_ms, struct timespec &ts);
+int absoluteTimeInFuture(uint64_t time_us, struct timespec &ts);
 
 /**
  * Get the absolute time off the system monotonic clock

--- a/framework/include/SyncObj.hpp
+++ b/framework/include/SyncObj.hpp
@@ -53,8 +53,8 @@ public:
 	void unlock();
 
 	// Returns 0 on success, ETIMEDOUT on timeout
-	// Use timeout_ms = 0 for blocking wait
-	int waitOnSignal(unsigned long timeout_ms);
+	// Use timeout_us = 0 for blocking wait
+	int waitOnSignal(unsigned long timeout_us);
 
 	void signal(void);
 

--- a/framework/src/DevMgr.cpp
+++ b/framework/src/DevMgr.cpp
@@ -317,7 +317,7 @@ int DevMgr::waitForUpdate(UpdateList &in_set, UpdateList &out_set, unsigned int 
 	g_wait_list.pushFront(&wl);
 	g_lock_dev_mgr->unlock();
 
-	int ret = wl.m_lock.waitOnSignal(timeout_ms);
+	int ret = wl.m_lock.waitOnSignal(timeout_ms*1000); // usecs needed
 	wl.m_lock.unlock();
 
 	// Remove the List item

--- a/framework/src/DevMgr.cpp
+++ b/framework/src/DevMgr.cpp
@@ -317,7 +317,7 @@ int DevMgr::waitForUpdate(UpdateList &in_set, UpdateList &out_set, unsigned int 
 	g_wait_list.pushFront(&wl);
 	g_lock_dev_mgr->unlock();
 
-	int ret = wl.m_lock.waitOnSignal(timeout_ms*1000); // usecs needed
+	int ret = wl.m_lock.waitOnSignal(timeout_ms * 1000); // usecs needed
 	wl.m_lock.unlock();
 
 	// Remove the List item

--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -478,18 +478,21 @@ void HRTWorkQueue::process(void)
 
 		uint64_t wait_time_usec = (next > now) ? next - now : 0;
 
-		// Wait granularity is 1ms
-		if (wait_time_usec > 1000) {
+		// Wait granularity is 200us
+		// TODO: this magic number needs checking
+		if (wait_time_usec > 200) {
 			// pthread_cond_timedwait uses absolute time
 			ts = offsetTimeToAbsoluteTime(next);
 
 			DF_LOG_DEBUG("HRTWorkQueue::process waiting for work (%" PRIi64 "usec)", wait_time_usec);
 			// Wait until next expiry or until a new item is rescheduled
 			m_reschedule.lock();
-			m_reschedule.waitOnSignal(wait_time_usec / 1000);
+			m_reschedule.waitOnSignal(wait_time_usec);
 			m_reschedule.unlock();
 			DF_LOG_DEBUG("Done wait");
 		}
+
+		DF_LOG_DEBUG("not waiting for work (%" PRIi64 "usec)", wait_time_usec);
 	}
 };
 

--- a/framework/src/SyncObj.cpp
+++ b/framework/src/SyncObj.cpp
@@ -84,14 +84,14 @@ void SyncObj::unlock()
 
 // waitOnSignal must be called inside a lock()
 // of this object
-int SyncObj::waitOnSignal(unsigned long timeout_ms)
+int SyncObj::waitOnSignal(unsigned long timeout_us)
 {
 	int ret;
-	DEBUG("wait %p %lu\n", &m_new_data_cond, timeout_ms);
+	DEBUG("wait %p %lu us\n", &m_new_data_cond, timeout_us);
 
-	if (timeout_ms) {
+	if (timeout_us) {
 		struct timespec ts;
-		ret = absoluteTimeInFuture(timeout_ms, ts);
+		ret = absoluteTimeInFuture(timeout_us, ts);
 		ret = ret ? ret : pthread_cond_timedwait(&m_new_data_cond, &m_lock, &ts);
 
 	} else {

--- a/framework/src/Time.cpp
+++ b/framework/src/Time.cpp
@@ -75,12 +75,12 @@ int DriverFramework::absoluteTime(struct timespec &ts)
 #endif
 }
 
-int DriverFramework::absoluteTimeInFuture(uint64_t time_ms, struct timespec &ts)
+int DriverFramework::absoluteTimeInFuture(uint64_t time_us, struct timespec &ts)
 {
 	int ret = absoluteTime(ts);
 
 	if (ret == 0) {
-		uint64_t nsecs = ts.tv_nsec + time_ms * 1000000;
+		uint64_t nsecs = ts.tv_nsec + time_us * 1000;
 		uint64_t secs = (nsecs / 1000000000);
 
 		ts.tv_sec += secs;

--- a/framework/src/WorkItems.cpp
+++ b/framework/src/WorkItems.cpp
@@ -53,7 +53,7 @@ bool WorkItems::isValidIndex(int index)
 
 bool WorkItems::_isValidIndex(int index)
 {
-	return (index >= 0 && (index < m_work_items.size()));
+	return (index >= 0 && (index < (int)m_work_items.size()));
 }
 
 void WorkItems::WorkItem::updateStats(unsigned int cur_usec)
@@ -175,7 +175,7 @@ void WorkItems::_unschedule(int index)
 
 		if (m_work_list.get(idx, cur_index)) {
 
-			if (cur_index == index) {
+			if ((int)cur_index == index) {
 				// remove unscheduled item
 				WorkItem *item = nullptr;
 

--- a/test/framework/SyncObjTest.cpp
+++ b/test/framework/SyncObjTest.cpp
@@ -47,9 +47,9 @@ void SyncObjTest::_doTests()
 	reportResult("Simple lock/unlock", passed);
 
 	uint64_t now = offsetTime();
-	unsigned long wait_in_ms = 5;
+	unsigned long wait_in_us = 5000;
 	so.lock();
-	int rv = so.waitOnSignal(wait_in_ms);
+	int rv = so.waitOnSignal(wait_in_us);
 	so.unlock();
 	uint64_t after = offsetTime();
 	uint64_t delta_usec = after - now;
@@ -59,10 +59,10 @@ void SyncObjTest::_doTests()
 		passed = false;
 	}
 
-	bool dtime_ok = (delta_usec > wait_in_ms * 1000) && (delta_usec < wait_in_ms * 1200);
+	bool dtime_ok = (delta_usec > wait_in_us) && (delta_usec < wait_in_us * 1.2f);
 
 	if (!dtime_ok) {
-		DF_LOG_ERR("waitSignal() timeout of %lums was %" PRIu64 "us", wait_in_ms, delta_usec);
+		DF_LOG_ERR("waitSignal() timeout of %luus was %" PRIu64 "us", wait_in_us, delta_usec);
 		passed = false;
 	}
 

--- a/test/framework/TimeTest.cpp
+++ b/test/framework/TimeTest.cpp
@@ -88,11 +88,11 @@ bool TimeTest::verifyAbsoluteTime()
 
 	int64_t seconds = delta.tv_sec + delta.tv_nsec / 1000000000;
 
-	int64_t msecs = delta.tv_sec * 1000 + delta.tv_nsec / 1000000 - seconds * 1000;
+	int64_t usecs = delta.tv_sec * 1000000 + delta.tv_nsec / 1000 - seconds * 1000000;
 
-	// sleep should be accurate withing 50ms
-	if (seconds != 2 || msecs > 50) {
-		DF_LOG_ERR("sleep(2) took %" PRId64 "sec %" PRId64 "ms", seconds, msecs);
+	// sleep should be accurate withing 50000us
+	if (seconds != 2 || usecs > 50000) {
+		DF_LOG_ERR("sleep(2) took %" PRId64 "sec %" PRId64 "us", seconds, usecs);
 		return false;
 	}
 
@@ -103,7 +103,7 @@ bool TimeTest::verifyAbsoluteTimeInFuture()
 {
 	struct timespec ts, ts2;
 
-	(void)absoluteTimeInFuture(2000, ts);
+	(void)absoluteTimeInFuture(2000000, ts);
 
 	sleep(2);
 
@@ -112,11 +112,11 @@ bool TimeTest::verifyAbsoluteTimeInFuture()
 	struct timespec delta = { ts2.tv_sec - ts.tv_sec, ts2.tv_nsec - ts.tv_nsec };
 
 	int64_t seconds = delta.tv_sec + delta.tv_nsec / 1000000000;
-	int64_t msecs = delta.tv_sec * 1000 + delta.tv_nsec / 1000000 - seconds * 1000;
+	int64_t usecs = delta.tv_sec * 1000000 + delta.tv_nsec / 1000 - seconds * 1000000;
 
-	// sleep should be accurate withing 50ms
-	if (seconds != 0 || msecs > 50) {
-		DF_LOG_ERR("sleep(2) took an extra %" PRId64 "sec %" PRId64 "ms", seconds, msecs);
+	// sleep should be accurate withing 50000us
+	if (seconds != 0 || usecs > 50000) {
+		DF_LOG_ERR("sleep(2) took an extra %" PRId64 "sec %" PRId64 "us", seconds, usecs);
 		return false;
 	}
 


### PR DESCRIPTION
By providing waitOnSignal with a us resolution instead of just ms resolution we can save a big amount of CPU load for SITL (and presumably also on Snapdragon).

This should help with https://github.com/PX4/Firmware/issues/4656.