### PR TITLE
framework: fix build for RPI2 (rebased)

### DIFF
--- a/cmake/toolchains/Toolchain-rpi2.cmake
+++ b/cmake/toolchains/Toolchain-rpi2.cmake
@@ -11,7 +11,8 @@ include(CMakeForceCompiler)
 
 add_definitions(
 	-D__RPI2
-	)
+	-D__DF_LINUX
+)
 
 ######### test DriverFramework for rpi2 ###
 # used for debug

--- a/framework/include/DriverFramework.hpp
+++ b/framework/include/DriverFramework.hpp
@@ -45,7 +45,7 @@
 #include "WorkMgr.hpp"
 #endif
 
-#if defined(__DF_LINUX) || defined(__RPI2)
+#ifdef __DF_LINUX
 // Show backtrace on error
 #define DF_ENABLE_BACKTRACE 1
 #endif

--- a/framework/include/DriverFramework.hpp
+++ b/framework/include/DriverFramework.hpp
@@ -94,5 +94,4 @@ public:
 	static void waitForShutdown();
 };
 
-};
-
+}

--- a/framework/include/DriverFramework.hpp
+++ b/framework/include/DriverFramework.hpp
@@ -45,7 +45,7 @@
 #include "WorkMgr.hpp"
 #endif
 
-#ifdef __DF_LINUX
+#if defined(__DF_LINUX) || defined(__RPI2)
 // Show backtrace on error
 #define DF_ENABLE_BACKTRACE 1
 #endif


### PR DESCRIPTION
This replaces #81.

Once travis is ok, we can merge this.