### PR TITLE
cmake: don't force compilers

### DIFF
--- a/cmake/toolchains/Toolchain-rpi2.cmake
+++ b/cmake/toolchains/Toolchain-rpi2.cmake
@@ -35,9 +35,6 @@ set(CMAKE_C_FLAGS "")
 set(LINKER_FLAGS "-Wl,-gc-sections")
 set(CMAKE_EXE_LINKER_FLAGS ${LINKER_FLAGS})
 
-CMAKE_FORCE_C_COMPILER(arm-linux-gnueabihf-gcc GNU)
-CMAKE_FORCE_CXX_COMPILER(arm-linux-gnueabihf-g++ GNU)
-
 # search for programs in the build host directories
 SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 # for libraries and headers in the target directories

--- a/cmake/toolchains/Toolchain-rpi2.cmake
+++ b/cmake/toolchains/Toolchain-rpi2.cmake
@@ -7,8 +7,6 @@
 # Author: Bo Liu (bo-rc@acm.org)
 #
 ############################################################################
-include(CMakeForceCompiler)
-
 add_definitions(
 	-D__RPI2
 	-D__DF_LINUX


### PR DESCRIPTION
This lead to some weird effects when the toolchains of RPi wasn't installed but the Qualcomm one was.

FYI: @eyeam3 