### PR TITLE
Fixes Implicit cast in DF for MPU9250

### DIFF
--- a/drivers/mpu9250/MPU9250.cpp
+++ b/drivers/mpu9250/MPU9250.cpp
@@ -498,7 +498,7 @@ void MPU9250::_measure()
 
 				// Initialize the temperature logic.
 				_last_temp_c = temp_c;
-				DF_LOG_INFO("IMU temperature initialized to: %f", temp_c);
+				DF_LOG_INFO("IMU temperature initialized to: %f", (double) temp_c);
 				_temp_initialized = true;
 			}
 


### PR DESCRIPTION
Fixes -Werror for Implicit conversion from float to double. This allows it build properly.