### PR TITLE
drivers/framework: remove devOpen/devClose

### DIFF
--- a/drivers/bmp280/BMP280.cpp
+++ b/drivers/bmp280/BMP280.cpp
@@ -192,16 +192,7 @@ int BMP280::bmp280_init()
 
 int BMP280::start()
 {
-	int result = devOpen(0);
-
-	/* Open the device path specified in the class initialization */
-	if (result < 0) {
-		DF_LOG_ERR("Unable to open the device path: %s", m_dev_path);
-		//goto exit;
-		return -1;
-	}
-
-	result = I2CDevObj::start();
+	int result = I2CDevObj::start();
 
 	if (result != 0) {
 		DF_LOG_ERR("error: could not start DevObj");
@@ -235,11 +226,6 @@ int BMP280::start()
 	}
 
 exit:
-
-	if (result != 0) {
-		devClose();
-	}
-
 	return result;
 }
 
@@ -249,13 +235,6 @@ int BMP280::stop()
 
 	if (result != 0) {
 		DF_LOG_ERR("DevObj stop failed");
-		return result;
-	}
-
-	result = devClose();
-
-	if (result != 0) {
-		DF_LOG_ERR("device close failed");
 		return result;
 	}
 

--- a/drivers/hmc5883/HMC5883.cpp
+++ b/drivers/hmc5883/HMC5883.cpp
@@ -131,16 +131,7 @@ int HMC5883::hmc5883_init()
 
 int HMC5883::start()
 {
-	int result = devOpen(0);
-
-	/* Open the device path specified in the class initialization */
-	if (result < 0) {
-		DF_LOG_ERR("Unable to open the device path: %s", m_dev_path);
-		//goto exit;
-		return -1;
-	}
-
-	result = I2CDevObj::start();
+	int result = I2CDevObj::start();
 
 	if (result != 0) {
 		DF_LOG_ERR("error: could not start DevObj");
@@ -174,11 +165,6 @@ int HMC5883::start()
 	}
 
 exit:
-
-	if (result != 0) {
-		devClose();
-	}
-
 	return result;
 }
 
@@ -193,14 +179,6 @@ int HMC5883::stop()
 
 	usleep(100000);
 
-	result = devClose();
-
-	if (result != 0) {
-		DF_LOG_ERR("device close failed");
-		return result;
-	}
-
-	usleep(100000);
 	return 0;
 }
 

--- a/drivers/isl29501/isl29501.cpp
+++ b/drivers/isl29501/isl29501.cpp
@@ -46,16 +46,7 @@ using namespace DriverFramework;
 int ISL29501::start()
 {
 
-	int result = devOpen(0);
-
-	/* Open the device path specified in the class initialization */
-	if (result < 0) {
-		DF_LOG_ERR("Unable to open the device path: %s", m_dev_path);
-		//goto exit;
-		return -1;
-	}
-
-	result = I2CDevObj::start();
+	int result = I2CDevObj::start();
 
 	if (result != 0) {
 		DF_LOG_ERR("error: could not start DevObj");
@@ -78,9 +69,7 @@ exit:
 
 	if (result != 0) {
 		DF_LOG_ERR("error: Failed to start ISL");
-		DevObj::stop();
 		I2CDevObj::stop();
-		devClose();
 	}
 
 	return result;
@@ -209,14 +198,6 @@ int ISL29501::stop()
 
 	usleep(100000);
 
-	result = devClose();
-
-	if (result != 0) {
-		DF_LOG_ERR("device close failed");
-		return result;
-	}
-
-	usleep(100000);
 	return 0;
 }
 

--- a/drivers/mpu9250/MPU9250.cpp
+++ b/drivers/mpu9250/MPU9250.cpp
@@ -287,11 +287,6 @@ int MPU9250::start()
 	}
 
 exit:
-
-	if (result != 0) {
-		devClose();
-	}
-
 	return result;
 }
 
@@ -315,13 +310,6 @@ int MPU9250::stop()
 	// We need to wait so that all measure calls are finished before
 	// closing the device.
 	usleep(10000);
-
-	result = devClose();
-
-	if (result != 0) {
-		DF_LOG_ERR("device close failed");
-		return result;
-	}
 
 	return 0;
 }

--- a/drivers/trone/TROne.cpp
+++ b/drivers/trone/TROne.cpp
@@ -42,16 +42,7 @@ using namespace DriverFramework;
 
 int TROne::start()
 {
-	int result = devOpen(0);
-
-	/* Open the device path specified in the class initialization */
-	if (result < 0) {
-		DF_LOG_ERR("Unable to open the device path: %s", m_dev_path);
-		//goto exit;
-		return -1;
-	}
-
-	result = I2CDevObj::start();
+	int result = I2CDevObj::start();
 
 	if (result != 0) {
 		DF_LOG_ERR("error: could not start DevObj");
@@ -91,13 +82,6 @@ int TROne::start()
 	}
 
 exit:
-
-	if (result != 0) {
-		DF_LOG_ERR("error: Failed to start TROne");
-		I2CDevObj::stop();
-		devClose();
-	}
-
 	return result;
 }
 
@@ -112,14 +96,6 @@ int TROne::stop()
 
 	usleep(100000);
 
-	result = devClose();
-
-	if (result != 0) {
-		DF_LOG_ERR("device close failed");
-		return result;
-	}
-
-	usleep(100000);
 	return 0;
 }
 

--- a/framework/include/I2CDevObj.hpp
+++ b/framework/include/I2CDevObj.hpp
@@ -71,22 +71,6 @@ public:
 	static int writeReg(DevHandle &h, uint8_t address, uint8_t *in_buffer, int length);
 
 protected:
-	int devOpen(int flags)
-	{
-		int fd = ::open(m_dev_instance_path, flags);
-
-		if (fd >= 0) {
-			m_fd = fd;
-		}
-
-		return (fd >= 0) ? 0 : -errno;
-	}
-
-	int devClose()
-	{
-		return ::close(m_fd);
-	}
-
 	int _readReg(uint8_t address, uint8_t *out_buffer, int length);
 	int _writeReg(uint8_t address, uint8_t *out_buffer, int length);
 

--- a/framework/include/SPIDevObj.hpp
+++ b/framework/include/SPIDevObj.hpp
@@ -90,22 +90,6 @@ protected:
 	int _bulkRead(uint8_t address, uint8_t *out_buffer, int length);
 	int _setBusFrequency(SPI_FREQUENCY freq_hz);
 
-	int devOpen(int flags)
-	{
-		int fd = ::open(m_dev_instance_path, flags);
-
-		if (fd >= 0) {
-			m_fd = fd;
-		}
-
-		return (fd >= 0) ? 0 : -errno;
-	}
-
-	int devClose()
-	{
-		return ::close(m_fd);
-	}
-
 	int m_fd = 0;
 };
 


### PR DESCRIPTION
These calls were actually always failing, however this didn't lead to an
error because errno which was returned was 0.
Also, the file descriptor m_fd written by devOpen is later overwritten
anyway in I2C/SPIDevObj::start().

Removing all the devOpen/devClose functionality didn't break anything,
so it was presumably unused.

The unit tests of the framework and all drivers still pass, and PX4 still runs on Snappy.

Thanks @eyeam3 for catching this.