### PR TITLE
test: remove timing tests in travis

### DIFF
--- a/test/framework/DFFrameworkTest.cpp
+++ b/test/framework/DFFrameworkTest.cpp
@@ -55,9 +55,12 @@ void DFFrameworkTest::_doTests()
 
 	reportResult("List tests", list_test.doTests());
 	reportResult("Sync tests", sync_test.doTests());
-	reportResult("Time tests", time_test.doTests());
 	reportResult("DevMgr tests", devmgr_test.doTests());
+#ifndef CI
+	// Don't do the tests in travis because timing is not reliable there.
+	reportResult("Time tests", time_test.doTests());
 	reportResult("WorkMgr tests", workmgr_test.doTests());
+#endif
 	// Add additional framework test do_test() calls here
 	//
 }

--- a/test/framework/TimeTest.cpp
+++ b/test/framework/TimeTest.cpp
@@ -39,17 +39,10 @@
 bool TimeTest::verifyOffsetTime()
 {
 
-#ifdef CI
-	const float error_factor = 3.0f;
-
-#else
-
 #ifdef __APPLE__
 	const float error_factor = 1.5f;
 #else
 	const float error_factor = 1.2f;
-#endif
-
 #endif
 
 	bool passed = true;

--- a/test/framework/WorkMgrTest.cpp
+++ b/test/framework/WorkMgrTest.cpp
@@ -81,18 +81,11 @@ static bool verifyDelay(WorkHandle &h, uint32_t delay_usec, int *arg)
 
 	cb_counter->unlock();
 
-#ifdef CI
-	const unsigned tolerance_us = 50000;
-#else
-
-
 #ifdef __APPLE__
 	// We need to be generous on Mac.
 	const unsigned tolerance_us = 1500;
 #else
 	const unsigned tolerance_us = 500;
-#endif
-
 #endif
 
 	usleep((delay_usec + tolerance_us) * 3);


### PR DESCRIPTION
It didn't seem feasible to do the timing sensitive tests on travis,
therefore just comment them out and save the pain.

Related to #104. 