### PR TITLE
Add driver for MS5607 and I2C functionality for Bebop(Linux)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build_linux
 build_rpi2
 build_qurt
+build_bebop

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build_linux
 build_rpi2
 build_qurt
 build_bebop
+__pycache__

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ define df_cmake_generate
 mkdir -p build_$(1) && cd build_$(1) && cmake .. -DOS=$(2) -DCMAKE_TOOLCHAIN_FILE=$(3) -DDF_ENABLE_TESTS=1
 endef
 
-rpi2 linux:
+rpi2 linux bebop:
 	$(call df_cmake_generate,$@,posix,cmake/toolchains/Toolchain-$@.cmake)
 	cd build_$@ && make
 

--- a/cmake/toolchains/Toolchain-bebop.cmake
+++ b/cmake/toolchains/Toolchain-bebop.cmake
@@ -7,7 +7,7 @@
 #
 ############################################################################
 add_definitions(
-	-D__BEBOP
+  -D__LINUX
 	)
 
 ######### test DriverFramework for bebop ###

--- a/cmake/toolchains/Toolchain-bebop.cmake
+++ b/cmake/toolchains/Toolchain-bebop.cmake
@@ -1,0 +1,39 @@
+############################################################################
+# Cross-compilation Toolchain File (CMAKE_TOOLCHAIN_FILE)
+# for Parrot Bebop
+#     requires a proper toolchain setup:
+#     https://github.com/pixhawk/rpi_toolchain
+#
+#
+############################################################################
+add_definitions(
+	-D__BEBOP
+	)
+
+######### test DriverFramework for bebop ###
+# used for debug
+#add_definitions(-DDF_DEBUG)
+
+if ("${RPI_TOOLCHAIN_DIR}" STREQUAL "")
+	set(RPI_TOOLCHAIN_DIR /opt/rpi_toolchain)
+endif()
+
+# this one is important
+set(CMAKE_SYSTEM_NAME Linux)
+
+# this one not so much
+set(CMAKE_SYSTEM_VERSION 1)
+
+# set cross compilers
+set(CMAKE_C_COMPILER "${RPI_TOOLCHAIN_DIR}/gcc-linaro-arm-linux-gnueabihf-raspbian/bin/arm-linux-gnueabihf-gcc")
+set(CMAKE_CXX_COMPILER "${RPI_TOOLCHAIN_DIR}/gcc-linaro-arm-linux-gnueabihf-raspbian/bin/arm-linux-gnueabihf-g++")
+set(CMAKE_C_FLAGS "-static" CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS "-static" CACHE STRING "" FORCE)
+set(LINKER_FLAGS "-Wl,-gc-sections")
+set(CMAKE_EXE_LINKER_FLAGS ${LINKER_FLAGS})
+
+# search for programs in the build host directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# for libraries and headers in the target directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/drivers/ms5607/CMakeLists.txt
+++ b/drivers/ms5607/CMakeLists.txt
@@ -1,0 +1,48 @@
+############################################################################
+#
+# Copyright (c) 2015 Mark Charlebois. All rights reserved.
+# Copyright (c) 2016 Michael Schaeuble. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+include(../../cmake/df_common.cmake)
+
+include_directories(../../framework/include)
+
+get_filename_component(drivername ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+df_add_library(df_${drivername}
+	MS5607.cpp
+	)
+
+if("${DF_ENABLE_TESTS}" STREQUAL "1")
+	add_subdirectory(test)
+endif()
+
+# vim: set noet fenc=utf-8 ff=unix ft=cmake :

--- a/drivers/ms5607/MS5607.cpp
+++ b/drivers/ms5607/MS5607.cpp
@@ -282,10 +282,6 @@ int MS5607::start()
 
 exit:
 
-	if (result != 0) {
-		devClose();
-	}
-
 	return result;
 }
 
@@ -295,13 +291,6 @@ int MS5607::stop()
 
 	if (result != 0) {
 		DF_LOG_ERR("DevObj stop failed");
-		return result;
-	}
-
-	result = devClose();
-
-	if (result != 0) {
-		DF_LOG_ERR("device close failed");
 		return result;
 	}
 

--- a/drivers/ms5607/MS5607.cpp
+++ b/drivers/ms5607/MS5607.cpp
@@ -101,7 +101,7 @@ int32_t MS5607::convertTemperature(int32_t adc_T)
 		off -= off2;
 	}
 
-	m_raw_sensor_convertion.temperature_c = temp;
+	m_raw_sensor_convertion.temperature_cc = temp;
 	m_raw_sensor_convertion.sens = sens;
 	m_raw_sensor_convertion.off = off;
 	return temp;

--- a/drivers/ms5607/MS5607.cpp
+++ b/drivers/ms5607/MS5607.cpp
@@ -35,61 +35,369 @@
 #include <string.h>
 #include "DriverFramework.hpp"
 #include "MS5607.hpp"
-#ifdef __QURT
-#include "dev_fs_lib_i2c.h"
-#endif
-
-#define MS5607_REG_ID 0xD0
-#define MS5607_REG_CTRL_MEAS 0xF4
-#define MS5607_REG_CONFIG 0xF5
-#define MS5607_REG_PRESS_MSB 0xF7
-
-#define MS5607_ID 0x58
-
-#define MS5607_BITS_CTRL_MEAS_OVERSAMPLING_TEMP2X     0b01000000
-#define MS5607_BITS_CTRL_MEAS_OVERSAMPLING_PRESSURE8X 0b00010000
-#define MS5607_BITS_CTRL_MEAS_POWER_MODE_NORMAL	      0b00000011
-
-#define MS5607_BITS_CONFIG_STANDBY_0MS5	0b00000000
-#define MS5607_BITS_CONFIG_FILTER_OFF	0b00000000
-#define MS5607_BITS_CONFIG_SPI_OFF	0b00000000
 
 using namespace DriverFramework;
 
+#define ADDR_RESET_CMD				0x1E	/* write to this address to reset chip */
+#define ADDR_CMD_CONVERT_D1_OSR256		0x40	/* write to this address to start pressure conversion */
+#define ADDR_CMD_CONVERT_D1_OSR512		0x42	/* write to this address to start pressure conversion */
+#define ADDR_CMD_CONVERT_D1_OSR1024		0x44	/* write to this address to start pressure conversion */
+#define ADDR_CMD_CONVERT_D1_OSR2048		0x46	/* write to this address to start pressure conversion */
+#define ADDR_CMD_CONVERT_D1_OSR4096		0x48	/* write to this address to start pressure conversion */
+#define ADDR_CMD_CONVERT_D2_OSR256		0x50	/* write to this address to start temperature conversion */
+#define ADDR_CMD_CONVERT_D2_OSR512		0x52	/* write to this address to start temperature conversion */
+#define ADDR_CMD_CONVERT_D2_OSR1024		0x54	/* write to this address to start temperature conversion */
+#define ADDR_CMD_CONVERT_D2_OSR2048		0x56	/* write to this address to start temperature conversion */
+#define ADDR_CMD_CONVERT_D2_OSR4096		0x58	/* write to this address to start temperature conversion */
+#define ADDR_CMD_CONVERT_D1   ADDR_CMD_CONVERT_D1_OSR1024
+#define ADDR_CMD_CONVERT_D2   ADDR_CMD_CONVERT_D2_OSR1024
+
+#define ADDR_CMD_ADC_READ     0x00
+#define ADDR_PROM_SETUP       0xA0  /* address of 8x 2 bytes factory and calibration data */
+
+#define POW2(_x) ((_x) * (_x))
+
 // convertPressure must be called after convertTemperature
-// as convertTemperature sets m_sensor_data.t_fine
+// as convertTemperature sets m_raw_sensor_convertion values
 int64_t MS5607::convertPressure(int64_t adc_P)
 {
-	return -1;
+  // Conversion from the datasheet
+  int64_t p = (((adc_P * m_raw_sensor_convertion.sens) >> 21) - m_raw_sensor_convertion.off) >> 15;
+  m_raw_sensor_convertion.pressure_mbar = p;
+	return p;
 }
 
 int32_t MS5607::convertTemperature(int32_t adc_T)
 {
-	return -1;
+  // Conversion from the datasheet
+  /* temperature offset (in ADC units) */
+  int32_t dT = adc_T - ((int32_t)m_sensor_calibration.c5_reference_temp << 8);
+
+  int64_t sens = ((int64_t)m_sensor_calibration.c1_pressure_sens << 16) 
+    + (((int64_t)m_sensor_calibration.c3_temp_coeff_pres_sens * dT) >> 7);
+
+  int64_t off = ((int64_t)m_sensor_calibration.c2_pressure_offset << 17) 
+    + (((int64_t)m_sensor_calibration.c4_temp_coeff_pres_offset * dT) >> 6);
+
+  /* absolute temperature in centidegrees - note intermediate value is outside 32-bit range */
+  int32_t temp =  2000 + (int32_t)(((int64_t)dT * m_sensor_calibration.c6_temp_coeff_temp) >> 23);
+
+  /* temperature compensation */
+  if (temp < 2000) 
+  {
+    int32_t t2 = POW2(dT) >> 31;
+
+    int64_t f = POW2((int64_t)temp - 2000);
+    int64_t off2 = 61 * f >> 4;
+    int64_t sens2 = 2 * f;
+
+    if (temp < -1500)
+    {
+      int64_t f2 = POW2(temp + 1500);
+      off2 += 15 * f2;
+      sens2 += 8 * f2;
+    }
+
+    temp -= t2;
+    sens -= sens2;
+    off -= off2;
+  }
+
+  m_raw_sensor_convertion.temperature_c = temp;
+  m_raw_sensor_convertion.sens = sens;
+  m_raw_sensor_convertion.off = off;
+  return temp;
 }
+
+/**
+* MS5611 crc4 cribbed from the datasheet
+*/
+bool MS5607::crc4(uint16_t *n_prom)
+{
+	int16_t cnt;
+	uint16_t n_rem;
+	uint16_t crc_read;
+	uint8_t n_bit;
+
+	n_rem = 0x00;
+
+	/* save the read crc */
+	crc_read = n_prom[7];
+
+	/* remove CRC byte */
+	n_prom[7] = (0xFF00 & (n_prom[7]));
+
+	for (cnt = 0; cnt < 16; cnt++) {
+		/* uneven bytes */
+		if (cnt & 1) {
+			n_rem ^= (uint8_t)((n_prom[cnt >> 1]) & 0x00FF);
+
+		} else {
+			n_rem ^= (uint8_t)(n_prom[cnt >> 1] >> 8);
+		}
+
+		for (n_bit = 8; n_bit > 0; n_bit--) {
+			if (n_rem & 0x8000) {
+				n_rem = (n_rem << 1) ^ 0x3000;
+
+			} else {
+				n_rem = (n_rem << 1);
+			}
+		}
+	}
+
+  /* final 4 bit remainder is CRC value */
+	n_rem = (0x000F & (n_rem >> 12));
+	n_prom[7] = crc_read;
+
+	/* return true if CRCs match */
+	return (0x000F & crc_read) == (n_rem ^ 0x00);
+}
+
 
 int MS5607::loadCalibration()
 {
-	return -1;
+  // Wait for PROM contents to be in the device (2.8 ms), in case we are called
+  // immediatelly after reset.
+  usleep(3000);
+
+  uint8_t last_val = 0;
+  bool bits_stuck = true;
+
+  uint8_t prom_buf[2];
+  union {
+    uint8_t b[2];
+    uint16_t w;
+  } cvt;
+
+  for (int i = 0; i < 8; ++i)
+  {
+    uint8_t cmd = ADDR_PROM_SETUP + (i * 2);
+
+    _retries = 5;
+    if (_transfer(MS5607_SLAVE_ADDRESS, &cmd, 1, &prom_buf[0], 2) < 0)
+    {
+      DF_LOG_ERR("Read calibration error");
+      break;
+    }
+
+    // check if all bytes are zero
+    if (i == 0)
+    {
+      last_val = prom_buf[0];
+    }
+
+    if (prom_buf[0] != last_val || prom_buf[1] != last_val)
+    {
+      bits_stuck = false;
+    }
+    cvt.b[0] = prom_buf[1];
+    cvt.b[1] = prom_buf[0];
+	  memcpy(((uint16_t*)&m_sensor_calibration + i), &cvt.w, sizeof(uint16_t));
+  }
+
+	DF_LOG_DEBUG("factory_setup: %d", m_sensor_calibration.factory_setup);
+	DF_LOG_DEBUG("c1: %d", m_sensor_calibration.c1_pressure_sens);
+	DF_LOG_DEBUG("c2: %d", m_sensor_calibration.c2_pressure_offset);
+	DF_LOG_DEBUG("c3: %d", m_sensor_calibration.c3_temp_coeff_pres_sens);
+	DF_LOG_DEBUG("c4: %d", m_sensor_calibration.c4_temp_coeff_pres_offset);
+	DF_LOG_DEBUG("c5: %d", m_sensor_calibration.c5_reference_temp);
+	DF_LOG_DEBUG("c6: %d", m_sensor_calibration.c6_temp_coeff_temp);
+
+	return (crc4((uint16_t*)&m_sensor_calibration) && !bits_stuck) ? 0 : -1;
 }
 
 int MS5607::ms5607_init()
 {
-  return -1;
+	/* Zero the struct */
+	m_synchronize.lock();
+
+	m_sensor_data.pressure_pa = 0.0f;
+	m_sensor_data.temperature_c = 0.0f;
+	m_sensor_data.last_read_time_usec = 0;
+	m_sensor_data.read_counter = 0;
+	m_sensor_data.error_counter = 0;
+	m_synchronize.unlock();
+
+  int result;
+
+	/* Reset sensor and load calibration data into internal register */
+	result = reset();
+
+	if (result < 0) {
+		DF_LOG_ERR("error: unable to communicate with the MS5607 pressure sensor");
+		return -EIO;
+	}
+
+	result = loadCalibration();
+
+	if (result != 0) {
+		DF_LOG_ERR("error: unable to complete initialization of the MS5607 pressure sensor");
+		return -EIO;
+	}
+
+  return 0;
+}
+
+int MS5607::reset()
+{
+  int result;
+	uint8_t cmd = ADDR_RESET_CMD;
+	_retries = 10;
+	result = _transfer(MS5607_SLAVE_ADDRESS, &cmd, 1, nullptr, 0);
+
+	if (result < 0)
+  {
+    DF_LOG_ERR("Unable to reset device: %d", result);
+    return -EIO;
+  }
+	return result;
 }
 
 int MS5607::start()
 {
-	return -1;
+	int result = 0;
+
+	result = I2CDevObj::start();
+
+	if (result != 0) {
+		DF_LOG_ERR("error: could not start DevObj");
+		goto exit;
+	}
+
+	/* Initialize the pressure sensor.*/
+	result = ms5607_init();
+
+	if (result != 0) {
+		DF_LOG_ERR("error: pressure sensor initialization failed, sensor read thread not started");
+		goto exit;
+	}
+
+	result = DevObj::start();
+
+	if (result != 0) {
+		DF_LOG_ERR("error: could not start DevObj");
+		goto exit;
+	}
+
+exit:
+
+	if (result != 0) {
+		devClose();
+	}
+
+	return result;
 }
 
 int MS5607::stop()
 {
-	return -1;
+	int result = DevObj::stop();
+
+	if (result != 0) {
+		DF_LOG_ERR("DevObj stop failed");
+		return result;
+	}
+
+	result = devClose();
+
+	if (result != 0) {
+		DF_LOG_ERR("device close failed");
+		return result;
+	}
+
+	return 0;
+}
+
+int MS5607::_request(uint8_t cmd)
+{
+  int ret;
+
+  _retries = 0;
+  ret = _transfer(MS5607_SLAVE_ADDRESS, &cmd, 1, nullptr, 0);
+
+  if (ret < 0)
+  {
+    DF_LOG_ERR("error: request failed");
+  }
+  return ret;
+}
+	
+int MS5607::_collect(uint32_t* raw)
+{
+  int ret;
+
+  union {
+    uint8_t b[4];
+    uint32_t w;
+  } cvt;
+
+  uint8_t buf[3];
+
+  _retries = 0;
+  uint8_t cmd = ADDR_CMD_ADC_READ;
+  ret = _transfer(MS5607_SLAVE_ADDRESS, &cmd, 1, &buf[0], 3);
+
+  if (ret < 0)
+  {
+    *raw = 0;
+    return -1;
+  }
+  cvt.b[0] = buf[2];
+  cvt.b[1] = buf[1];
+  cvt.b[2] = buf[0];
+  cvt.b[3] = 0;
+  *raw = cvt.w;
+
+  return 0;
 }
 
 void MS5607::_measure(void)
 {
+
+  // Request to convert the temperature
+  if (_request(ADDR_CMD_CONVERT_D2) < 0)
+  {
+    DF_LOG_ERR("error: temp measure failed");
+    return;
+  }
+
+  usleep(MS5607_CONVERSION_INTERVAL_US);
+
+  // read the result
+  uint32_t temperature_from_sensor;
+	if (_collect(&temperature_from_sensor) < 0) {
+		DF_LOG_ERR("error: temp collect failed");
+		reset();
+		return;
+	}
+
+  // Request to convert the pressure
+  if (_request(ADDR_CMD_CONVERT_D1) < 0)
+  {
+    DF_LOG_ERR("error: pressure measure failed");
+    return;
+  }
+
+  usleep(MS5607_CONVERSION_INTERVAL_US);
+
+  // read the result
+  uint32_t pressure_from_sensor;
+	if (_collect(&pressure_from_sensor) < 0) {
+		DF_LOG_ERR("error: pressure collect failed");
+		return;
+	}
+
+	m_synchronize.lock();
+
+	m_sensor_data.temperature_c = convertTemperature(temperature_from_sensor) / 100.0;
+	m_sensor_data.pressure_pa = convertPressure(pressure_from_sensor);
+	m_sensor_data.last_read_time_usec = DriverFramework::offsetTime();
+	m_sensor_data.read_counter++;
+
+	_publish(m_sensor_data);
+
+	m_synchronize.signal();
+	m_synchronize.unlock();
 }
 
 int MS5607::_publish(struct baro_sensor_data &data)

--- a/drivers/ms5607/MS5607.cpp
+++ b/drivers/ms5607/MS5607.cpp
@@ -1,0 +1,99 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2015 Mark Charlebois. All rights reserved.
+ *   Copyright (C) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <string.h>
+#include "DriverFramework.hpp"
+#include "MS5607.hpp"
+#ifdef __QURT
+#include "dev_fs_lib_i2c.h"
+#endif
+
+#define MS5607_REG_ID 0xD0
+#define MS5607_REG_CTRL_MEAS 0xF4
+#define MS5607_REG_CONFIG 0xF5
+#define MS5607_REG_PRESS_MSB 0xF7
+
+#define MS5607_ID 0x58
+
+#define MS5607_BITS_CTRL_MEAS_OVERSAMPLING_TEMP2X     0b01000000
+#define MS5607_BITS_CTRL_MEAS_OVERSAMPLING_PRESSURE8X 0b00010000
+#define MS5607_BITS_CTRL_MEAS_POWER_MODE_NORMAL	      0b00000011
+
+#define MS5607_BITS_CONFIG_STANDBY_0MS5	0b00000000
+#define MS5607_BITS_CONFIG_FILTER_OFF	0b00000000
+#define MS5607_BITS_CONFIG_SPI_OFF	0b00000000
+
+using namespace DriverFramework;
+
+// convertPressure must be called after convertTemperature
+// as convertTemperature sets m_sensor_data.t_fine
+int64_t MS5607::convertPressure(int64_t adc_P)
+{
+	return -1;
+}
+
+int32_t MS5607::convertTemperature(int32_t adc_T)
+{
+	return -1;
+}
+
+int MS5607::loadCalibration()
+{
+	return -1;
+}
+
+int MS5607::ms5607_init()
+{
+  return -1;
+}
+
+int MS5607::start()
+{
+	return -1;
+}
+
+int MS5607::stop()
+{
+	return -1;
+}
+
+void MS5607::_measure(void)
+{
+}
+
+int MS5607::_publish(struct baro_sensor_data &data)
+{
+	// TBD
+	return -1;
+}

--- a/drivers/ms5607/MS5607.hpp
+++ b/drivers/ms5607/MS5607.hpp
@@ -40,7 +40,7 @@ namespace DriverFramework
 {
 
 struct ms5607_sensor_calibration {
-  uint16_t factory_setup;
+	uint16_t factory_setup;
 	uint16_t c1_pressure_sens;
 	uint16_t c2_pressure_offset;
 	uint16_t c3_temp_coeff_pres_sens;
@@ -51,10 +51,10 @@ struct ms5607_sensor_calibration {
 };
 
 struct ms5607_sensor_measurement {
-  int32_t temperature_c;
-  int64_t off;
-  int64_t sens;
-  int32_t pressure_mbar;
+	int32_t temperature_c;
+	int64_t off;
+	int64_t sens;
+	int32_t pressure_mbar;
 };
 
 #define BARO_DEVICE_PATH "/dev/i2c-ms5607"
@@ -105,10 +105,10 @@ private:
 
 	int loadCalibration();
 
-  // Request to convert pressure or temperature data
+	// Request to convert pressure or temperature data
 	int _request(uint8_t phase);
 	// Read out the requested sensor data
-	int _collect(uint32_t* raw);
+	int _collect(uint32_t *raw);
 
 	bool crc4(uint16_t *n_prom);
 

--- a/drivers/ms5607/MS5607.hpp
+++ b/drivers/ms5607/MS5607.hpp
@@ -51,7 +51,7 @@ struct ms5607_sensor_calibration {
 };
 
 struct ms5607_sensor_measurement {
-	int32_t temperature_c; // Temperature with 0.01 DegC resolution 2356 = 23.56 DegC
+	int32_t temperature_cc; // Temperature with 0.01 DegC resolution 2356 = 23.56 DegC
 	int64_t off; // Offset at actual temperature
 	int64_t sens; // Sensitivity at actual temperature
 	int32_t pressure_mbar; // Temperature compensated pressure with 0.01 mbar resolution

--- a/drivers/ms5607/MS5607.hpp
+++ b/drivers/ms5607/MS5607.hpp
@@ -51,10 +51,10 @@ struct ms5607_sensor_calibration {
 };
 
 struct ms5607_sensor_measurement {
-	int32_t temperature_c;
-	int64_t off;
-	int64_t sens;
-	int32_t pressure_mbar;
+	int32_t temperature_c; // Temperature with 0.01 DegC resolution 2356 = 23.56 DegC
+	int64_t off; // Offset at actual temperature
+	int64_t sens; // Sensitivity at actual temperature
+	int32_t pressure_mbar; // Temperature compensated pressure with 0.01 mbar resolution
 };
 
 #define BARO_DEVICE_PATH "/dev/i2c-ms5607"

--- a/drivers/ms5607/MS5607.hpp
+++ b/drivers/ms5607/MS5607.hpp
@@ -1,0 +1,102 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2015 Mark Charlebois. All rights reserved.
+ *   Copyright (C) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "BaroSensor.hpp"
+
+namespace DriverFramework
+{
+
+struct ms5607_sensor_calibration {
+};
+
+
+#define BARO_DEVICE_PATH "/dev/i2c-ms5607"
+
+// update frequency is 50 Hz (44.4-51.3Hz ) at 8x oversampling
+#define MS5607_MEASURE_INTERVAL_US 20000
+
+#define MS5607_BUS_FREQUENCY_IN_KHZ 400
+#define MS5607_TRANSFER_TIMEOUT_IN_USECS 9000
+
+#define MS5607_MAX_LEN_SENSOR_DATA_BUFFER_IN_BYTES 6
+#define MS5607_MAX_LEN_CALIB_VALUES 26
+
+// TODO: include some common header file (currently in drv_sensor.h).
+#define DRV_DF_DEVTYPE_MS5607 0x42
+
+#define MS5607_SLAVE_ADDRESS 0b1110110       /* 7-bit slave address */
+
+
+class MS5607 : public BaroSensor
+{
+public:
+	MS5607(const char *device_path) :
+		BaroSensor(device_path, MS5607_MEASURE_INTERVAL_US)
+	{
+		m_id.dev_id_s.devtype = DRV_DF_DEVTYPE_MS5607;
+		m_id.dev_id_s.address = MS5607_SLAVE_ADDRESS;
+	}
+
+	// @return 0 on success, -errno on failure
+	virtual int start();
+
+	// @return 0 on success, -errno on failure
+	virtual int stop();
+
+protected:
+	virtual void _measure();
+	virtual int _publish(struct baro_sensor_data &data);
+
+private:
+	// Returns pressure in Pa as unsigned 32 bit integer in
+	// Q24.8 format (24 integer bits and 8 fractional bits)
+	// Output value of “24674867” represents
+	// 24674867/256 = 96386.2 Pa = 963.862 hPa
+	int64_t convertPressure(int64_t adc_pressure);
+
+	// Returns temperature in DegC, resolution is 0.01 DegC
+	// Output value of “5123” equals 51.23 DegC
+	int32_t convertTemperature(int32_t adc_temperature);
+
+	int loadCalibration();
+
+	// returns 0 on success, -errno on failure
+	int ms5607_init();
+
+	struct ms5607_sensor_calibration 	m_sensor_calibration;
+};
+
+}; // namespace DriverFramework

--- a/drivers/ms5607/test/CMakeLists.txt
+++ b/drivers/ms5607/test/CMakeLists.txt
@@ -1,0 +1,51 @@
+############################################################################
+#
+# Copyright (c) 2015 Mark Charlebois. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+include_directories(..)
+
+if("${DF_TARGET}" STREQUAL "qurt")
+	add_subdirectory(qurt)
+else()
+	add_executable(df_ms5607_test
+		main.cpp
+		test.cpp
+		)
+
+	target_link_libraries(df_ms5607_test
+		df_driver_framework
+		df_ms5607
+		${df_link_libs}
+		)
+endif()
+
+# vim: set noet fenc=utf-8 ff=unix ft=cmake :

--- a/drivers/ms5607/test/main.cpp
+++ b/drivers/ms5607/test/main.cpp
@@ -1,0 +1,39 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2015 Mark Charlebois. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+extern int do_test();
+
+int main()
+{
+	return do_test();
+}

--- a/drivers/ms5607/test/test.cpp
+++ b/drivers/ms5607/test/test.cpp
@@ -1,0 +1,141 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2015 Mark Charlebois. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+#include <unistd.h>
+#include "DriverFramework.hpp"
+#include "MS5607.hpp"
+
+
+using namespace DriverFramework;
+
+class PressureTester
+{
+public:
+	static const int TEST_PASS = 0;
+	static const int TEST_FAIL = 1;
+
+	PressureTester() :
+		m_sensor(BARO_DEVICE_PATH)
+	{}
+
+	static void readSensorCallback(void *arg);
+
+	int run(void);
+
+private:
+	void readSensor();
+	void wait();
+
+	MS5607		m_sensor;
+	uint32_t 	m_read_attempts = 0;
+	uint32_t 	m_read_counter = 0;
+	struct baro_sensor_data m_sensor_data;
+
+	int		m_pass;
+	bool		m_done = false;
+};
+
+int PressureTester::run()
+{
+	DF_LOG_INFO("Entering: run");
+	// Default is fail unless pass critera met
+	m_pass = TEST_FAIL;
+
+	// Register the driver
+	int ret = m_sensor.init();
+
+	// Open the pressure sensor
+	DevHandle h;
+	DevMgr::getHandle(BARO_DEVICE_PATH, h);
+
+	if (!h.isValid()) {
+		DF_LOG_INFO("Error: unable to obtain a valid handle for the receiver at: %s (%d)",
+			    BARO_DEVICE_PATH, h.getError());
+		m_done = true;
+
+	} else {
+		m_done = false;
+		m_sensor_data.read_counter = 0;
+	}
+
+	while (!m_done) {
+		++m_read_attempts;
+		ret = BaroSensor::getSensorData(h, m_sensor_data, true);
+		DF_LOG_INFO("Got data");
+
+		if (ret == 0) {
+			uint32_t count = m_sensor_data.read_counter;
+
+			if (m_read_counter != count) {
+				DF_LOG_INFO("count: %d", count);
+				m_read_counter = count;
+				BaroSensor::printPressureValues(m_sensor_data);
+			}
+
+		} else {
+			DF_LOG_INFO("error: unable to read the pressure sensor device.");
+		}
+
+		if ((m_read_counter >= 1000) && (m_read_attempts == m_read_counter)) {
+			// Done test - PASSED
+			m_pass = TEST_PASS;
+			m_done = true;
+
+		} else if (m_read_attempts > 1000) {
+			DF_LOG_INFO("error: unable to read the pressure sensor device.");
+			m_done = true;
+		}
+	}
+
+	DF_LOG_INFO("Closing pressure sensor\n");
+	m_sensor.stop();
+	return m_pass;
+}
+
+int do_test()
+{
+	int ret = Framework::initialize();
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	PressureTester pt;
+
+	ret = pt.run();
+
+	Framework::shutdown();
+
+	DF_LOG_INFO("Test %s", (ret == PressureTester::TEST_PASS) ? "PASSED" : "FAILED");
+	return ret;
+}
+

--- a/framework/include/I2CDevObj.hpp
+++ b/framework/include/I2CDevObj.hpp
@@ -70,14 +70,14 @@ public:
 	static int readReg(DevHandle &h, uint8_t address, uint8_t *out_buffer, int length);
 	static int writeReg(DevHandle &h, uint8_t address, uint8_t *in_buffer, int length);
 	static int transfer(DevHandle &h, uint8_t address, uint8_t *send_buffer, uint8_t send_len,
-	    uint8_t *receive_buffer, uint8_t receive_len);
+			    uint8_t *receive_buffer, uint8_t receive_len);
 
 protected:
 	int _readReg(uint8_t address, uint8_t *out_buffer, int length);
 	int _writeReg(uint8_t address, uint8_t *out_buffer, int length);
 
 	int _transfer(uint8_t address, const uint8_t *send_buffer, uint8_t send_len,
-	    uint8_t *receive_buffer, uint8_t receive_len);
+		      uint8_t *receive_buffer, uint8_t receive_len);
 
 	// read from a register without ioctl
 	int _simple_read(uint8_t *out_buffer, int length);

--- a/framework/include/I2CDevObj.hpp
+++ b/framework/include/I2CDevObj.hpp
@@ -69,10 +69,15 @@ public:
 
 	static int readReg(DevHandle &h, uint8_t address, uint8_t *out_buffer, int length);
 	static int writeReg(DevHandle &h, uint8_t address, uint8_t *in_buffer, int length);
+	static int transfer(DevHandle &h, uint8_t address, uint8_t *send_buffer, uint8_t send_len,
+	    uint8_t *receive_buffer, uint8_t receive_len);
 
 protected:
 	int _readReg(uint8_t address, uint8_t *out_buffer, int length);
 	int _writeReg(uint8_t address, uint8_t *out_buffer, int length);
+
+	int _transfer(uint8_t address, const uint8_t *send_buffer, uint8_t send_len,
+	    uint8_t *receive_buffer, uint8_t receive_len);
 
 	// read from a register without ioctl
 	int _simple_read(uint8_t *out_buffer, int length);
@@ -80,7 +85,8 @@ protected:
 	int _setSlaveConfig(uint32_t slave_address, uint32_t bus_frequency_khz,
 			    uint32_t transfer_timeout_usec);
 
-	int m_fd = 0;
+	int m_fd;
+	uint16_t _retries;
 };
 
 };

--- a/framework/src/I2CDevObj.cpp
+++ b/framework/src/I2CDevObj.cpp
@@ -42,6 +42,10 @@
 #include "DevIOCTL.h"
 #ifdef __QURT
 #include "dev_fs_lib_i2c.h"
+#elif defined(__BEBOP)
+#include <sys/ioctl.h>
+#include <linux/i2c-dev.h>
+#include <linux/i2c.h>
 #endif
 
 using namespace DriverFramework;
@@ -131,6 +135,8 @@ int I2CDevObj::_readReg(uint8_t address, uint8_t *out_buffer, int length)
 	}
 
 	return 0;
+#elif defined(__BEBOP)
+  return -1;
 #else
 	return -1;
 #endif
@@ -158,6 +164,8 @@ int I2CDevObj::_simple_read(uint8_t *out_buffer, int length)
 	}
 
 	return 0;
+#elif defined(__BEBOP)
+  return -1;
 #else
 	return -1;
 #endif
@@ -205,7 +213,85 @@ int I2CDevObj::_setSlaveConfig(uint32_t slave_address, uint32_t bus_frequency_kh
 	slave_config.bus_frequency_in_khz = bus_frequency_khz;
 	slave_config.byte_transer_timeout_in_usecs = transfer_timeout_usec;
 	return ::ioctl(m_fd, I2C_IOCTL_SLAVE, &slave_config);
+#elif defined(__BEBOP)
+  return -1;
 #else
 	return -1;
+#endif
+}
+
+int I2CDevObj::transfer(DevHandle &h, uint8_t address, uint8_t *send_buffer,
+    uint8_t send_len, uint8_t *receive_buffer, uint8_t receive_len)
+{
+	I2CDevObj *obj = DevMgr::getDevObjByHandle<I2CDevObj>(h);
+
+	if (obj) {
+		return obj->_transfer(address, send_buffer, send_len, receive_buffer, receive_len);
+
+	} else {
+		return -1;
+	}
+}
+
+int I2CDevObj::_transfer(uint8_t address, const uint8_t *send_buffer,
+    uint8_t send_len, uint8_t *receive_buffer, uint8_t receive_len)
+{
+	if (m_fd == 0) {
+		DF_LOG_ERR("error: i2c bus is not yet opened");
+		return -1;
+	}
+
+
+#if defined(__BEBOP)
+	struct i2c_msg msgv[2];
+	uint32_t msgs;
+	struct i2c_rdwr_ioctl_data packets;
+	int ret;
+	uint16_t retry_count = 0;
+
+	do {
+		msgs = 0;
+
+		if (send_len > 0) {
+			msgv[msgs].addr = address;
+			msgv[msgs].flags = 0;
+			msgv[msgs].buf = const_cast<uint8_t *>(send_buffer);
+			msgv[msgs].len = send_len;
+			msgs++;
+		}
+
+		if (receive_len > 0) {
+			msgv[msgs].addr = address;
+			msgv[msgs].flags = I2C_M_RD;
+			msgv[msgs].buf = receive_buffer;
+			msgv[msgs].len = receive_len;
+			msgs++;
+		}
+
+		if (msgs == 0) {
+		  DF_LOG_ERR("Message empty");
+			return -1;
+		}
+
+		packets.msgs  = msgv;
+		packets.nmsgs = msgs;
+
+    ret = ::ioctl(m_fd, I2C_RDWR, (uint32_t*)&packets);
+
+    if (ret < 0) {
+      DF_LOG_ERR("I2C transfer failed: %s", strerror(errno));
+      return ret;
+		}
+
+		/* success */
+		if (ret >= 0) {
+			break;
+		}
+
+	} while (retry_count++ < _retries);
+
+	return ret;
+#else
+  return -1;
 #endif
 }

--- a/framework/src/I2CDevObj.cpp
+++ b/framework/src/I2CDevObj.cpp
@@ -136,7 +136,7 @@ int I2CDevObj::_readReg(uint8_t address, uint8_t *out_buffer, int length)
 
 	return 0;
 #elif defined(__BEBOP)
-  return -1;
+	return -1;
 #else
 	return -1;
 #endif
@@ -165,7 +165,7 @@ int I2CDevObj::_simple_read(uint8_t *out_buffer, int length)
 
 	return 0;
 #elif defined(__BEBOP)
-  return -1;
+	return -1;
 #else
 	return -1;
 #endif
@@ -214,14 +214,14 @@ int I2CDevObj::_setSlaveConfig(uint32_t slave_address, uint32_t bus_frequency_kh
 	slave_config.byte_transer_timeout_in_usecs = transfer_timeout_usec;
 	return ::ioctl(m_fd, I2C_IOCTL_SLAVE, &slave_config);
 #elif defined(__BEBOP)
-  return -1;
+	return -1;
 #else
 	return -1;
 #endif
 }
 
 int I2CDevObj::transfer(DevHandle &h, uint8_t address, uint8_t *send_buffer,
-    uint8_t send_len, uint8_t *receive_buffer, uint8_t receive_len)
+			uint8_t send_len, uint8_t *receive_buffer, uint8_t receive_len)
 {
 	I2CDevObj *obj = DevMgr::getDevObjByHandle<I2CDevObj>(h);
 
@@ -234,7 +234,7 @@ int I2CDevObj::transfer(DevHandle &h, uint8_t address, uint8_t *send_buffer,
 }
 
 int I2CDevObj::_transfer(uint8_t address, const uint8_t *send_buffer,
-    uint8_t send_len, uint8_t *receive_buffer, uint8_t receive_len)
+			 uint8_t send_len, uint8_t *receive_buffer, uint8_t receive_len)
 {
 	if (m_fd == 0) {
 		DF_LOG_ERR("error: i2c bus is not yet opened");
@@ -269,18 +269,18 @@ int I2CDevObj::_transfer(uint8_t address, const uint8_t *send_buffer,
 		}
 
 		if (msgs == 0) {
-		  DF_LOG_ERR("Message empty");
+			DF_LOG_ERR("Message empty");
 			return -1;
 		}
 
 		packets.msgs  = msgv;
 		packets.nmsgs = msgs;
 
-    ret = ::ioctl(m_fd, I2C_RDWR, (uint32_t*)&packets);
+		ret = ::ioctl(m_fd, I2C_RDWR, (uint32_t *)&packets);
 
-    if (ret < 0) {
-      DF_LOG_ERR("I2C transfer failed: %s", strerror(errno));
-      return ret;
+		if (ret < 0) {
+			DF_LOG_ERR("I2C transfer failed: %s", strerror(errno));
+			return ret;
 		}
 
 		/* success */
@@ -292,6 +292,6 @@ int I2CDevObj::_transfer(uint8_t address, const uint8_t *send_buffer,
 
 	return ret;
 #else
-  return -1;
+	return -1;
 #endif
 }

--- a/framework/src/I2CDevObj.cpp
+++ b/framework/src/I2CDevObj.cpp
@@ -42,7 +42,7 @@
 #include "DevIOCTL.h"
 #ifdef __QURT
 #include "dev_fs_lib_i2c.h"
-#elif defined(__BEBOP)
+#elif defined(__LINUX)
 #include <sys/ioctl.h>
 #include <linux/i2c-dev.h>
 #include <linux/i2c.h>
@@ -135,7 +135,7 @@ int I2CDevObj::_readReg(uint8_t address, uint8_t *out_buffer, int length)
 	}
 
 	return 0;
-#elif defined(__BEBOP)
+#elif defined(__LINUX)
 	return -1;
 #else
 	return -1;
@@ -164,7 +164,7 @@ int I2CDevObj::_simple_read(uint8_t *out_buffer, int length)
 	}
 
 	return 0;
-#elif defined(__BEBOP)
+#elif defined(__LINUX)
 	return -1;
 #else
 	return -1;
@@ -213,7 +213,7 @@ int I2CDevObj::_setSlaveConfig(uint32_t slave_address, uint32_t bus_frequency_kh
 	slave_config.bus_frequency_in_khz = bus_frequency_khz;
 	slave_config.byte_transer_timeout_in_usecs = transfer_timeout_usec;
 	return ::ioctl(m_fd, I2C_IOCTL_SLAVE, &slave_config);
-#elif defined(__BEBOP)
+#elif defined(__LINUX)
 	return -1;
 #else
 	return -1;
@@ -242,7 +242,7 @@ int I2CDevObj::_transfer(uint8_t address, const uint8_t *send_buffer,
 	}
 
 
-#if defined(__BEBOP)
+#if defined(__LINUX)
 	struct i2c_msg msgv[2];
 	uint32_t msgs;
 	struct i2c_rdwr_ioctl_data packets;


### PR DESCRIPTION
This is a driver for the MS5607 barometer sensor. It is based on the MS5611 driver of the PX4/Firmware and adapted as needed.
Furthermore, the I2C functionality is extended for posix platforms. This is also based on the PX4/Firmware and tested on the Parrot Bebop. The communication should work on RPis, too, but is not tested so far.