### PR TITLE
ms5607: don't compile for QURT

### DIFF
--- a/drivers/ms5607/test/CMakeLists.txt
+++ b/drivers/ms5607/test/CMakeLists.txt
@@ -34,7 +34,7 @@
 include_directories(..)
 
 if("${DF_TARGET}" STREQUAL "qurt")
-	add_subdirectory(qurt)
+	# Don't compile this driver for Snapdragon.
 else()
 	add_executable(df_ms5607_test
 		main.cpp


### PR DESCRIPTION
The MS5607 is only on Bebop, not Snapdragon, so no need to compile for QURT.