### PR TITLE
Add Driver for MPU6050

### DIFF
--- a/cmake/toolchains/Toolchain-bebop.cmake
+++ b/cmake/toolchains/Toolchain-bebop.cmake
@@ -9,12 +9,11 @@
 add_definitions(
   -D__LINUX
   -D__BEBOP
-  -D__IMU_USE_I2C
 )
 
 ######### test DriverFramework for bebop ###
 # used for debug
-#add_definitions(-DDF_DEBUG)
+# add_definitions(-DDF_DEBUG)
 
 if ("${RPI_TOOLCHAIN_DIR}" STREQUAL "")
 	set(RPI_TOOLCHAIN_DIR /opt/rpi_toolchain)

--- a/cmake/toolchains/Toolchain-bebop.cmake
+++ b/cmake/toolchains/Toolchain-bebop.cmake
@@ -7,7 +7,9 @@
 #
 ############################################################################
 add_definitions(
-	-D__LINUX
+  -D__LINUX
+  -D__BEBOP
+  -D__IMU_USE_I2C
 )
 
 ######### test DriverFramework for bebop ###

--- a/drivers/mpu6050/CMakeLists.txt
+++ b/drivers/mpu6050/CMakeLists.txt
@@ -1,0 +1,49 @@
+############################################################################
+#
+# Copyright (C) 2016 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+include(../../cmake/df_common.cmake)
+
+include_directories(
+	../../framework/include
+	)
+
+get_filename_component(drivername ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+df_add_library(df_${drivername}
+	MPU6050.cpp
+	)
+
+if("${DF_ENABLE_TESTS}" STREQUAL "1")
+	add_subdirectory(test)
+endif()
+
+# vim: set noet fenc=utf-8 ff=unix ft=cmake :

--- a/drivers/mpu6050/MPU6050.cpp
+++ b/drivers/mpu6050/MPU6050.cpp
@@ -138,7 +138,7 @@ struct fifo_packet {
 
 // Length of the FIFO used by the sensor to buffer unread
 // sensor data.
-#define MPU_MAX_LEN_FIFO_IN_BYTES 512
+#define MPU_MAX_LEN_FIFO_IN_BYTES 1024
 
 // Uncomment to allow additional debug output to be generated.
 // #define MPU6050_DEBUG 1
@@ -238,6 +238,7 @@ int MPU6050::mpu6050_init()
 
 	// Set sample frequency
 	// Using the 260 Hz setting leads to many memory corruptions and errors
+	// TODO Check if this could be improved
 	bits = BITS_DLPF_CFG_184HZ;
 	result = _writeReg(MPUREG_CONFIG, &bits, 1);
 

--- a/drivers/mpu6050/MPU6050.cpp
+++ b/drivers/mpu6050/MPU6050.cpp
@@ -37,6 +37,112 @@
 #include "DriverFramework.hpp"
 #include "MPU6050.hpp"
 
+struct fifo_packet {
+	int16_t accel_x;
+	int16_t accel_y;
+	int16_t accel_z;
+	int16_t temp;
+	int16_t gyro_x;
+	int16_t gyro_y;
+	int16_t gyro_z;
+};
+
+#define MPU6050_ONE_G	9.80665f
+
+#define MIN(_x, _y) (_x) > (_y) ? (_y) : (_x)
+
+#ifndef M_PI_F
+#define M_PI_F 3.14159265358979323846f
+#endif
+
+// -2000 to 2000 degrees/s, 16 bit signed register, deg to rad conversion
+#define GYRO_RAW_TO_RAD_S 	 (2000.0f / 32768.0f * M_PI_F / 180.0f)
+
+#define DIR_READ			0x80
+#define DIR_WRITE			0x00
+
+// MPU 6000 registers
+#define MPUREG_WHOAMI			0x75
+#define MPUREG_SMPLRT_DIV		0x19
+#define MPUREG_CONFIG			0x1A
+#define MPUREG_GYRO_CONFIG		0x1B
+#define MPUREG_ACCEL_CONFIG		0x1C
+#define MPUREG_FIFO_EN			0x23
+#define MPUREG_INT_PIN_CFG		0x37
+#define MPUREG_INT_ENABLE		0x38
+#define MPUREG_INT_STATUS		0x3A
+#define MPUREG_ACCEL_XOUT_H		0x3B
+#define MPUREG_ACCEL_XOUT_L		0x3C
+#define MPUREG_ACCEL_YOUT_H		0x3D
+#define MPUREG_ACCEL_YOUT_L		0x3E
+#define MPUREG_ACCEL_ZOUT_H		0x3F
+#define MPUREG_ACCEL_ZOUT_L		0x40
+#define MPUREG_TEMP_OUT_H		0x41
+#define MPUREG_TEMP_OUT_L		0x42
+#define MPUREG_GYRO_XOUT_H		0x43
+#define MPUREG_GYRO_XOUT_L		0x44
+#define MPUREG_GYRO_YOUT_H		0x45
+#define MPUREG_GYRO_YOUT_L		0x46
+#define MPUREG_GYRO_ZOUT_H		0x47
+#define MPUREG_GYRO_ZOUT_L		0x48
+#define MPUREG_USER_CTRL		0x6A
+#define MPUREG_PWR_MGMT_1		0x6B
+#define MPUREG_PWR_MGMT_2		0x6C
+#define MPUREG_FIFO_COUNTH		0x72
+#define MPUREG_FIFO_COUNTL		0x73
+#define MPUREG_FIFO_R_W			0x74
+#define MPUREG_PRODUCT_ID		0x0C
+#define MPUREG_TRIM1			0x0D
+#define MPUREG_TRIM2			0x0E
+#define MPUREG_TRIM3			0x0F
+#define MPUREG_TRIM4			0x10
+
+// Configuration bits MPU 3000 and MPU 6000 (not revised)?
+#define BIT_SLEEP			0x40
+#define BIT_H_RESET			0x80
+#define BITS_CLKSEL			0x07
+#define MPU_CLK_SEL_PLLGYROX		0x01
+#define MPU_CLK_SEL_PLLGYROZ		0x03
+#define MPU_EXT_SYNC_GYROX		0x02
+#define BITS_GYRO_ST_X			0x80
+#define BITS_GYRO_ST_Y			0x40
+#define BITS_GYRO_ST_Z			0x20
+#define BITS_FS_250DPS			0x00
+#define BITS_FS_500DPS			0x08
+#define BITS_FS_1000DPS			0x10
+#define BITS_FS_2000DPS			0x18
+#define BITS_ACCEL_CONFIG_2G 0x00
+#define BITS_ACCEL_CONFIG_4G 0x08
+#define BITS_ACCEL_CONFIG_8G 0x10
+#define BITS_ACCEL_CONFIG_16G 0x18
+#define BITS_FS_MASK			0x18
+#define BITS_DLPF_CFG_256HZ_NOLPF2	0x00
+#define BITS_DLPF_CFG_188HZ		0x01
+#define BITS_DLPF_CFG_98HZ		0x02
+#define BITS_DLPF_CFG_42HZ		0x03
+#define BITS_DLPF_CFG_20HZ		0x04
+#define BITS_DLPF_CFG_10HZ		0x05
+#define BITS_DLPF_CFG_5HZ		0x06
+#define BITS_DLPF_CFG_2100HZ_NOLPF	0x07
+#define BITS_DLPF_CFG_MASK		0x07
+#define BIT_INT_ANYRD_2CLEAR		0x10
+#define BIT_RAW_RDY_EN			0x01
+#define BIT_I2C_IF_DIS			0x10
+#define BIT_INT_STATUS_DATA		0x01
+#define BITS_USER_CTRL_FIFO_RST 0x04
+#define BITS_USER_CTRL_I2C_MST_EN 0x20
+#define BITS_USER_CTRL_FIFO_EN 0x40
+#define BITS_FIFO_ENABLE_TEMP_OUT 0x80
+#define BITS_FIFO_ENABLE_GYRO_XOUT 0x40
+#define BITS_FIFO_ENABLE_GYRO_YOUT 0x20
+#define BITS_FIFO_ENABLE_GYRO_ZOUT 0x10
+#define BITS_FIFO_ENABLE_ACCEL 0x08
+#define BITS_INT_STATUS_FIFO_OVERFLOW 0x10
+
+// Length of the FIFO used by the sensor to buffer unread
+// sensor data.
+#define MPU_MAX_LEN_FIFO_IN_BYTES 512
+
 // Uncomment to allow additional debug output to be generated.
 // #define MPU6050_DEBUG 1
 
@@ -44,7 +150,6 @@ using namespace DriverFramework;
 
 int MPU6050::mpu6050_init()
 {
-  // TODO Add implementation
 	/* Zero the struct */
 	m_synchronize.lock();
 
@@ -71,43 +176,390 @@ int MPU6050::mpu6050_init()
 
 	m_synchronize.unlock();
 
-	return -1;
+	int result = _setSlaveConfig(MPU6050_SLAVE_ADDRESS,
+				     MPU6050_BUS_FREQUENCY_IN_KHZ,
+				     MPU6050_TRANSFER_TIMEOUT_IN_USECS);
+
+	if (result < 0) {
+	  DF_LOG_ERR("Could not set slave config");
+	}
+	  
+  uint8_t bits = BIT_H_RESET;
+	result = _writeReg(MPUREG_PWR_MGMT_1, &bits, 1);
+
+	if (result < 0) {
+		DF_LOG_ERR("Reset failed");
+		return -1;
+	}
+
+	usleep(100000);
+
+	DF_LOG_INFO("Reset MPU6050");
+	bits = MPU_CLK_SEL_PLLGYROZ;
+	result = _writeReg(MPUREG_PWR_MGMT_1, &bits, 1);
+
+	if (result < 0) {
+		DF_LOG_ERR("Wakeup sensor failed");
+		return -1;
+	}
+
+	usleep(1000);
+
+  bits = 0;
+	result = _writeReg(MPUREG_PWR_MGMT_2, &bits, 1);
+
+	if (result < 0) {
+		DF_LOG_ERR("enable failed");
+		return -1;
+	}
+
+	usleep(1000);
+
+	// Enable I2C again and start FIFO.
+	bits = BITS_USER_CTRL_FIFO_RST | BITS_USER_CTRL_I2C_MST_EN;
+	result = _writeReg(MPUREG_USER_CTRL, &bits, 1);
+
+	if (result < 0) {
+		DF_LOG_ERR("User ctrl failed");
+		return -1;
+	}
+
+	usleep(1000);
+
+  bits = BITS_FIFO_ENABLE_TEMP_OUT | BITS_FIFO_ENABLE_GYRO_XOUT
+          | BITS_FIFO_ENABLE_GYRO_YOUT
+          | BITS_FIFO_ENABLE_GYRO_ZOUT | BITS_FIFO_ENABLE_ACCEL;
+  result = _writeReg(MPUREG_FIFO_EN,
+          &bits, 1);
+
+	if (result < 0) {
+		DF_LOG_ERR("FIFO enable failed");
+		return -1;
+	}
+
+	usleep(1000);
+
+  // Set external frame synchronization gyro_xout
+  bits = 0x20;
+	result = _writeReg(MPUREG_CONFIG, &bits, 1); // TODO chekc value
+
+	if (result < 0) {
+		DF_LOG_ERR("Config failed");
+		return -1;
+	}
+
+	usleep(1000);
+
+  // Set the gyro resolution
+  bits = BITS_FS_2000DPS;
+	result = _writeReg(MPUREG_GYRO_CONFIG, &bits, 1);
+
+	if (result < 0) {
+		DF_LOG_ERR("Gyro scale config failed");
+		return -1;
+	}
+
+	usleep(1000);
+
+  // Set the accel resolution
+  bits = BITS_ACCEL_CONFIG_16G;
+	result = _writeReg(MPUREG_ACCEL_CONFIG, &bits, 1);
+
+	if (result < 0) {
+		DF_LOG_ERR("Accel scale config failed");
+		return -1;
+	}
+
+	usleep(1000);
+
+	// Enable/clear the FIFO of any residual data
+	reset_fifo();
+
+	return 0;
 }
 
 int MPU6050::mpu6050_deinit()
 {
-  // TODO Add implementation
-	return -1;
+	// Leave the IMU in a reset state (turned off).
+	uint8_t bits = BIT_H_RESET;
+	int result = _writeReg(MPUREG_PWR_MGMT_1, &bits, 1);
+
+	if (result != 0) {
+		DF_LOG_ERR("reset failed");
+	}
+
+	return 0;
 }
 
 int MPU6050::start()
 {
-  // TODO Add implementation
-	return -1;
+	/* Open the device path specified in the class initialization. */
+	// attempt to open device in start()
+	int result = I2CDevObj::start();
+
+	if (result < 0) {
+		DF_LOG_ERR("DevObj start failed");
+		DF_LOG_ERR("Unable to open the device path: %s", m_dev_path);
+		return result;
+	}
+
+	result = _setSlaveConfig(MPU6050_SLAVE_ADDRESS,
+				     MPU6050_BUS_FREQUENCY_IN_KHZ,
+				     MPU6050_TRANSFER_TIMEOUT_IN_USECS);
+
+	if (result < 0) {
+	  DF_LOG_ERR("Could not set slave config");
+	}
+	  
+	/* Try to talk to the sensor. */
+	uint8_t sensor_id;
+	result = _readReg(MPUREG_WHOAMI, &sensor_id, 1);
+
+	if (result < 0) {
+		DF_LOG_ERR("Unable to communicate with the sensor");
+		return -1;
+	}
+
+	if (sensor_id != MPU_WHOAMI_6050) {
+		DF_LOG_ERR("MPU6050 sensor WHOAMI wrong: 0x%X, should be: 0x%X",
+			   sensor_id, MPU_WHOAMI_6050);
+		result = -1;
+		goto exit;
+	}
+
+	result = mpu6050_init();
+
+	if (result != 0) {
+		DF_LOG_ERR("error: IMU sensor initialization failed, sensor read thread not started");
+		goto exit;
+	}
+
+	result = DevObj::start();
+
+	if (result != 0) {
+		DF_LOG_ERR("DevObj start failed");
+		return result;
+	}
+
+exit:
+	return result;
 }
 
 int MPU6050::stop()
 {
-  // TODO Add implementation
-	return -1;
+	int result = mpu6050_deinit();
+
+	if (result < 0) {
+		DF_LOG_ERR(
+			"error: IMU sensor de-initialization failed.");
+		return result;
+	}
+
+	result = DevObj::stop();
+
+	if (result != 0) {
+		DF_LOG_ERR("DevObj stop failed");
+		return result;
+	}
+
+	// We need to wait so that all measure calls are finished before
+	// closing the device.
+	usleep(10000);
+
+	return 0;
 }
 
 int MPU6050::get_fifo_count()
 {
-  // TODO Add implementation
-  return -1;
+	int16_t num_bytes = 0x0;
+
+	int result = _readReg(MPUREG_FIFO_COUNTH, (uint8_t *) &num_bytes, sizeof(num_bytes));
+
+	if (result < 0) {
+		DF_LOG_ERR("FIFO count read failed");
+		return 0;
+	}
+
+	num_bytes = swap16(num_bytes);
+
+	return num_bytes;
+
 }
 
 void MPU6050::reset_fifo()
 {
-  // TODO Add implementation
-  return;
+  uint8_t bits = BITS_USER_CTRL_FIFO_RST | BITS_USER_CTRL_FIFO_EN;
+	int result = _writeReg(MPUREG_USER_CTRL, &bits, 1);
+
+	if (result < 0) {
+		DF_LOG_ERR("FIFO reset failed");
+	}
 }
 
 void MPU6050::_measure()
 {
-  // TODO Add implementation
+	uint8_t int_status = 0;
+	int result = _readReg(MPUREG_INT_STATUS, &int_status, 1);
+
+	if (result < 0) {
+		m_synchronize.lock();
+		++m_sensor_data.error_counter;
+		m_synchronize.unlock();
 		return;
+	}
+
+	if (int_status & BITS_INT_STATUS_FIFO_OVERFLOW) {
+		reset_fifo();
+
+		m_synchronize.lock();
+		++m_sensor_data.fifo_overflow_counter;
+		DF_LOG_ERR("FIFO overflow: %d", (int)m_sensor_data.fifo_overflow_counter);
+		m_synchronize.unlock();
+
+		//return;
+	}
+
+	int size_of_fifo_packet = sizeof(fifo_packet);
+
+	// Get FIFO byte count to read and floor it to the report size.
+	int bytes_to_read = get_fifo_count() / size_of_fifo_packet
+			    * size_of_fifo_packet;
+
+	if (bytes_to_read <= 0) {
+		m_synchronize.lock();
+		++m_sensor_data.error_counter;
+		m_synchronize.unlock();
+		return;
+	}
+
+	// Allocate a buffer large enough for n complete packets, read from the
+	// sensor FIFO.
+	const unsigned buf_len = (MPU_MAX_LEN_FIFO_IN_BYTES / size_of_fifo_packet) * size_of_fifo_packet;
+	uint8_t fifo_read_buf[buf_len];
+
+	const unsigned read_len = MIN((unsigned)bytes_to_read, buf_len);
+	memset(fifo_read_buf, 0x0, buf_len);
+
+	result = _readReg(MPUREG_FIFO_R_W, fifo_read_buf, read_len);
+
+	if (result < 0) {
+		m_synchronize.lock();
+		++m_sensor_data.error_counter;
+		m_synchronize.unlock();
+		return;
+	}
+
+	for (unsigned packet_index = 0; packet_index < read_len / size_of_fifo_packet; ++packet_index) {
+
+		fifo_packet *report = (fifo_packet *)(&fifo_read_buf[packet_index	* size_of_fifo_packet]);
+
+		report->accel_x = swap16(report->accel_x);
+		report->accel_y = swap16(report->accel_y);
+		report->accel_z = swap16(report->accel_z);
+		report->temp = swap16(report->temp);
+		report->gyro_x = swap16(report->gyro_x);
+		report->gyro_y = swap16(report->gyro_y);
+		report->gyro_z = swap16(report->gyro_z);
+
+
+		// Check if the full accel range of the accel has been used. If this occurs, it is
+		// either a spike due to a crash/landing or a sign that the vibrations levels
+		// measured are excessive.
+		if (report->accel_x == INT16_MIN || report->accel_x == INT16_MAX ||
+		    report->accel_y == INT16_MIN || report->accel_y == INT16_MAX ||
+		    report->accel_z == INT16_MIN || report->accel_z == INT16_MAX) {
+			m_synchronize.lock();
+			++m_sensor_data.accel_range_hit_counter;
+			m_synchronize.unlock();
+		}
+
+		// Also check the full gyro range, however, this is very unlikely to happen.
+		if (report->gyro_x == INT16_MIN || report->gyro_x == INT16_MAX ||
+		    report->gyro_y == INT16_MIN || report->gyro_y == INT16_MAX ||
+		    report->gyro_z == INT16_MIN || report->gyro_z == INT16_MAX) {
+			m_synchronize.lock();
+			++m_sensor_data.gyro_range_hit_counter;
+			m_synchronize.unlock();
+		}
+
+		const float temp_c = float(report->temp) / 340.0f + 36.53f;
+
+		// Use the temperature field to try to detect if we (ever) fall out of sync with
+		// the FIFO buffer. If the temperature changes insane amounts, reset the FIFO logic
+		// and return early.
+		if (!_temp_initialized) {
+			// Assume that the temperature should be in a sane range of -40 to 85 deg C which is
+			// the specified temperature range, at least to initialize.
+			if (temp_c > -40.0f && temp_c < 85.0f) {
+
+				// Initialize the temperature logic.
+				_last_temp_c = temp_c;
+				DF_LOG_INFO("IMU temperature initialized to: %f", (double) temp_c);
+				_temp_initialized = true;
+			}
+
+		} else {
+			// Once initialized, check for a temperature change of more than 2 degrees which
+			// points to a FIFO corruption.
+			if (fabsf(temp_c - _last_temp_c) > 2.0f) {
+				DF_LOG_ERR(
+					"FIFO corrupt, temp difference: %f, last temp: %f, current temp: %f",
+					fabs(temp_c - _last_temp_c), (double)_last_temp_c, (double)temp_c);
+				reset_fifo();
+				_temp_initialized = false;
+				m_synchronize.lock();
+				++m_sensor_data.fifo_corruption_counter;
+				m_synchronize.unlock();
+				return;
+			}
+
+			_last_temp_c = temp_c;
+		}
+
+		m_synchronize.lock();
+		m_sensor_data.accel_m_s2_x = float(report->accel_x)
+					     * (MPU6050_ONE_G / 2048.0f);
+		m_sensor_data.accel_m_s2_y = float(report->accel_y)
+					     * (MPU6050_ONE_G / 2048.0f);
+		m_sensor_data.accel_m_s2_z = float(report->accel_z)
+					     * (MPU6050_ONE_G / 2048.0f);
+		m_sensor_data.temp_c = temp_c;
+		m_sensor_data.gyro_rad_s_x = float(report->gyro_x) * GYRO_RAW_TO_RAD_S;
+		m_sensor_data.gyro_rad_s_y = float(report->gyro_y) * GYRO_RAW_TO_RAD_S;
+		m_sensor_data.gyro_rad_s_z = float(report->gyro_z) * GYRO_RAW_TO_RAD_S;
+
+		// Pass on the sampling interval between FIFO samples at 8kHz.
+		m_sensor_data.fifo_sample_interval_us = 125;
+
+		// Flag if this is the last sample, and _publish() should wrap up the data it has received.
+		m_sensor_data.is_last_fifo_sample = ((packet_index + 1) == (read_len / size_of_fifo_packet));
+
+		++m_sensor_data.read_counter;
+
+		// Generate debug output every second, assuming that a sample is generated every
+		// 125 usecs
+#ifdef MPU6050_DEBUG
+
+		if (++m_sensor_data.read_counter % (1000000 / 125) == 0) {
+
+			DF_LOG_INFO("IMU: accel: [%f, %f, %f]",
+				    (double)m_sensor_data.accel_m_s2_x,
+				    (double)m_sensor_data.accel_m_s2_y,
+				    (double)m_sensor_data.accel_m_s2_z);
+			DF_LOG_INFO("     gyro:  [%f, %f, %f]",
+				    (double)m_sensor_data.gyro_rad_s_x,
+				    (double)m_sensor_data.gyro_rad_s_y,
+				    (double)m_sensor_data.gyro_rad_s_z);
+			DF_LOG_INFO("    temp:  %f C", (double)m_sensor_data.temp_c);
+		}
+
+#endif
+
+		_publish(m_sensor_data);
+
+		m_synchronize.signal();
+		m_synchronize.unlock();
+	}
 }
 
 int MPU6050::_publish(struct imu_sensor_data &data)

--- a/drivers/mpu6050/MPU6050.cpp
+++ b/drivers/mpu6050/MPU6050.cpp
@@ -1,0 +1,117 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2016 Julian Oes. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <stdint.h>
+#include <string.h>
+#include "math.h"
+#include "DriverFramework.hpp"
+#include "MPU6050.hpp"
+
+// Uncomment to allow additional debug output to be generated.
+// #define MPU6050_DEBUG 1
+
+using namespace DriverFramework;
+
+int MPU6050::mpu6050_init()
+{
+  // TODO Add implementation
+	/* Zero the struct */
+	m_synchronize.lock();
+
+	m_sensor_data.accel_m_s2_x = 0.0f;
+	m_sensor_data.accel_m_s2_y = 0.0f;
+	m_sensor_data.accel_m_s2_z = 0.0f;
+	m_sensor_data.gyro_rad_s_x = 0.0f;
+	m_sensor_data.gyro_rad_s_y = 0.0f;
+	m_sensor_data.gyro_rad_s_z = 0.0f;
+	m_sensor_data.mag_ga_x = 0.0f;
+	m_sensor_data.mag_ga_y = 0.0f;
+	m_sensor_data.mag_ga_z = 0.0f;
+	m_sensor_data.temp_c = 0.0f;
+
+	m_sensor_data.read_counter = 0;
+	m_sensor_data.error_counter = 0;
+	m_sensor_data.fifo_overflow_counter = 0;
+	m_sensor_data.fifo_corruption_counter = 0;
+	m_sensor_data.gyro_range_hit_counter = 0;
+	m_sensor_data.accel_range_hit_counter = 0;
+
+	m_sensor_data.fifo_sample_interval_us = 0;
+	m_sensor_data.is_last_fifo_sample = false;
+
+	m_synchronize.unlock();
+
+	return -1;
+}
+
+int MPU6050::mpu6050_deinit()
+{
+  // TODO Add implementation
+	return -1;
+}
+
+int MPU6050::start()
+{
+  // TODO Add implementation
+	return -1;
+}
+
+int MPU6050::stop()
+{
+  // TODO Add implementation
+	return -1;
+}
+
+int MPU6050::get_fifo_count()
+{
+  // TODO Add implementation
+  return -1;
+}
+
+void MPU6050::reset_fifo()
+{
+  // TODO Add implementation
+  return;
+}
+
+void MPU6050::_measure()
+{
+  // TODO Add implementation
+		return;
+}
+
+int MPU6050::_publish(struct imu_sensor_data &data)
+{
+	// TBD
+	return -1;
+}

--- a/drivers/mpu6050/MPU6050.cpp
+++ b/drivers/mpu6050/MPU6050.cpp
@@ -138,6 +138,13 @@ struct fifo_packet {
 #define BITS_FIFO_ENABLE_GYRO_ZOUT 0x10
 #define BITS_FIFO_ENABLE_ACCEL 0x08
 #define BITS_INT_STATUS_FIFO_OVERFLOW 0x10
+#define BITS_DLPF_CFG_260HZ		0x00
+#define BITS_DLPF_CFG_184HZ		0x01
+#define BITS_DLPF_CFG_94HZ		0x02
+#define BITS_DLPF_CFG_44HZ		0x03
+#define BITS_DLPF_CFG_21HZ		0x04
+#define BITS_DLPF_CFG_10HZ		0x05
+#define BITS_DLPF_CFG_5HZ		0x06
 
 // Length of the FIFO used by the sensor to buffer unread
 // sensor data.
@@ -240,8 +247,8 @@ int MPU6050::mpu6050_init()
 	usleep(1000);
 
   // Set external frame synchronization gyro_xout
-  bits = 0x20;
-	result = _writeReg(MPUREG_CONFIG, &bits, 1); // TODO chekc value
+  bits = BITS_DLPF_CFG_184HZ;
+	result = _writeReg(MPUREG_CONFIG, &bits, 1);
 
 	if (result < 0) {
 		DF_LOG_ERR("Config failed");

--- a/drivers/mpu6050/MPU6050.cpp
+++ b/drivers/mpu6050/MPU6050.cpp
@@ -178,10 +178,10 @@ int MPU6050::mpu6050_init()
 				     MPU6050_TRANSFER_TIMEOUT_IN_USECS);
 
 	if (result < 0) {
-	  DF_LOG_ERR("Could not set slave config");
+		DF_LOG_ERR("Could not set slave config");
 	}
-	  
-  uint8_t bits = BIT_H_RESET;
+
+	uint8_t bits = BIT_H_RESET;
 	result = _writeReg(MPUREG_PWR_MGMT_1, &bits, 1);
 
 	if (result < 0) {
@@ -201,8 +201,8 @@ int MPU6050::mpu6050_init()
 
 	usleep(1000);
 
-  // Don't set sensors into standby mode
-  bits = 0;
+	// Don't set sensors into standby mode
+	bits = 0;
 	result = _writeReg(MPUREG_PWR_MGMT_2, &bits, 1);
 
 	if (result < 0) {
@@ -223,11 +223,11 @@ int MPU6050::mpu6050_init()
 
 	usleep(1000);
 
-  bits = BITS_FIFO_ENABLE_TEMP_OUT | BITS_FIFO_ENABLE_GYRO_XOUT
-          | BITS_FIFO_ENABLE_GYRO_YOUT
-          | BITS_FIFO_ENABLE_GYRO_ZOUT | BITS_FIFO_ENABLE_ACCEL;
-  result = _writeReg(MPUREG_FIFO_EN,
-          &bits, 1);
+	bits = BITS_FIFO_ENABLE_TEMP_OUT | BITS_FIFO_ENABLE_GYRO_XOUT
+	       | BITS_FIFO_ENABLE_GYRO_YOUT
+	       | BITS_FIFO_ENABLE_GYRO_ZOUT | BITS_FIFO_ENABLE_ACCEL;
+	result = _writeReg(MPUREG_FIFO_EN,
+			   &bits, 1);
 
 	if (result < 0) {
 		DF_LOG_ERR("FIFO enable failed");
@@ -236,9 +236,9 @@ int MPU6050::mpu6050_init()
 
 	usleep(1000);
 
-  // Set sample frequency
-  // Using the 260 Hz setting leads to many memory corruptions and errors
-  bits = BITS_DLPF_CFG_184HZ;
+	// Set sample frequency
+	// Using the 260 Hz setting leads to many memory corruptions and errors
+	bits = BITS_DLPF_CFG_184HZ;
 	result = _writeReg(MPUREG_CONFIG, &bits, 1);
 
 	if (result < 0) {
@@ -248,8 +248,8 @@ int MPU6050::mpu6050_init()
 
 	usleep(1000);
 
-  // Set the gyro resolution
-  bits = BITS_FS_2000DPS;
+	// Set the gyro resolution
+	bits = BITS_FS_2000DPS;
 	result = _writeReg(MPUREG_GYRO_CONFIG, &bits, 1);
 
 	if (result < 0) {
@@ -259,8 +259,8 @@ int MPU6050::mpu6050_init()
 
 	usleep(1000);
 
-  // Set the accel resolution
-  bits = BITS_ACCEL_CONFIG_16G;
+	// Set the accel resolution
+	bits = BITS_ACCEL_CONFIG_16G;
 	result = _writeReg(MPUREG_ACCEL_CONFIG, &bits, 1);
 
 	if (result < 0) {
@@ -302,13 +302,13 @@ int MPU6050::start()
 	}
 
 	result = _setSlaveConfig(MPU6050_SLAVE_ADDRESS,
-				     MPU6050_BUS_FREQUENCY_IN_KHZ,
-				     MPU6050_TRANSFER_TIMEOUT_IN_USECS);
+				 MPU6050_BUS_FREQUENCY_IN_KHZ,
+				 MPU6050_TRANSFER_TIMEOUT_IN_USECS);
 
 	if (result < 0) {
-	  DF_LOG_ERR("Could not set slave config");
+		DF_LOG_ERR("Could not set slave config");
 	}
-	  
+
 	/* Try to talk to the sensor. */
 	uint8_t sensor_id;
 	result = _readReg(MPUREG_WHOAMI, &sensor_id, 1);
@@ -386,7 +386,7 @@ int MPU6050::get_fifo_count()
 
 void MPU6050::reset_fifo()
 {
-  uint8_t bits = BITS_USER_CTRL_FIFO_RST | BITS_USER_CTRL_FIFO_EN;
+	uint8_t bits = BITS_USER_CTRL_FIFO_RST | BITS_USER_CTRL_FIFO_EN;
 	int result = _writeReg(MPUREG_USER_CTRL, &bits, 1);
 
 	if (result < 0) {

--- a/drivers/mpu6050/MPU6050.hpp
+++ b/drivers/mpu6050/MPU6050.hpp
@@ -36,16 +36,16 @@
 #define __IMU_USE_I2C
 #include "ImuSensor.hpp"
 
-#define DRV_DF_DEVTYPE_MPU6050 0x45 // TODO check settin
+#define DRV_DF_DEVTYPE_MPU6050 0x45
 
 #define MPU_WHOAMI_6050		 0x68
 #define MPU6050_SLAVE_ADDRESS 0x68       /* 7-bit slave address */
 
 // update frequency 2000 Hz
-#define MPU6050_MEASURE_INTERVAL_US 500 // TODO check setting
+#define MPU6050_MEASURE_INTERVAL_US 500
 
-#define MPU6050_BUS_FREQUENCY_IN_KHZ 400 // TODO check setting
-#define MPU6050_TRANSFER_TIMEOUT_IN_USECS 400 // TODO check setting
+#define MPU6050_BUS_FREQUENCY_IN_KHZ 400
+#define MPU6050_TRANSFER_TIMEOUT_IN_USECS 400
 
 namespace DriverFramework
 {
@@ -59,8 +59,7 @@ public:
 		_temp_initialized(false)
 	{
 		m_id.dev_id_s.devtype = DRV_DF_DEVTYPE_MPU6050;
-		// TODO: does the WHOAMI make sense as an address?
-		m_id.dev_id_s.address = MPU_WHOAMI_6050;
+		m_id.dev_id_s.address = MPU6050_SLAVE_ADDRESS;
 	}
 
 	// @return 0 on success, -errno on failure

--- a/drivers/mpu6050/MPU6050.hpp
+++ b/drivers/mpu6050/MPU6050.hpp
@@ -33,7 +33,6 @@
 
 #pragma once
 
-#define __IMU_USE_I2C
 #include "ImuSensor.hpp"
 
 #define DRV_DF_DEVTYPE_MPU6050 0x45

--- a/drivers/mpu6050/MPU6050.hpp
+++ b/drivers/mpu6050/MPU6050.hpp
@@ -45,7 +45,7 @@
 #define MPU6050_MEASURE_INTERVAL_US 500 // TODO check setting
 
 #define MPU6050_BUS_FREQUENCY_IN_KHZ 400 // TODO check setting
-#define MPU6050_TRANSFER_TIMEOUT_IN_USECS 900 // TODO check setting
+#define MPU6050_TRANSFER_TIMEOUT_IN_USECS 400 // TODO check setting
 
 namespace DriverFramework
 {

--- a/drivers/mpu6050/MPU6050.hpp
+++ b/drivers/mpu6050/MPU6050.hpp
@@ -33,15 +33,19 @@
 
 #pragma once
 
-#define IMU_USE_I2C
+#define __IMU_USE_I2C
 #include "ImuSensor.hpp"
 
 #define DRV_DF_DEVTYPE_MPU6050 0x45 // TODO check settin
 
-#define MPU_WHOAMI_6050		 0x75 // TODO check settin
+#define MPU_WHOAMI_6050		 0x68
+#define MPU6050_SLAVE_ADDRESS 0x68       /* 7-bit slave address */
 
-// update frequency 1000 Hz
-#define MPU6050_MEASURE_INTERVAL_US 1000 // TODO check setting
+// update frequency 2000 Hz
+#define MPU6050_MEASURE_INTERVAL_US 500 // TODO check setting
+
+#define MPU6050_BUS_FREQUENCY_IN_KHZ 400 // TODO check setting
+#define MPU6050_TRANSFER_TIMEOUT_IN_USECS 900 // TODO check setting
 
 namespace DriverFramework
 {

--- a/drivers/mpu6050/MPU6050.hpp
+++ b/drivers/mpu6050/MPU6050.hpp
@@ -40,11 +40,11 @@
 #define MPU_WHOAMI_6050		 0x68
 #define MPU6050_SLAVE_ADDRESS 0x68       /* 7-bit slave address */
 
-// update frequency 2000 Hz
-#define MPU6050_MEASURE_INTERVAL_US 500
+// update frequency 1000 Hz
+#define MPU6050_MEASURE_INTERVAL_US 1000
 
 #define MPU6050_BUS_FREQUENCY_IN_KHZ 400
-#define MPU6050_TRANSFER_TIMEOUT_IN_USECS 400
+#define MPU6050_TRANSFER_TIMEOUT_IN_USECS 900
 
 namespace DriverFramework
 {

--- a/drivers/mpu6050/MPU6050.hpp
+++ b/drivers/mpu6050/MPU6050.hpp
@@ -33,6 +33,7 @@
 
 #pragma once
 
+#define __IMU_USE_I2C
 #include "ImuSensor.hpp"
 
 #define DRV_DF_DEVTYPE_MPU6050 0x45

--- a/drivers/mpu6050/MPU6050.hpp
+++ b/drivers/mpu6050/MPU6050.hpp
@@ -1,0 +1,90 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#define IMU_USE_I2C
+#include "ImuSensor.hpp"
+
+#define DRV_DF_DEVTYPE_MPU6050 0x45 // TODO check settin
+
+#define MPU_WHOAMI_6050		 0x75 // TODO check settin
+
+// update frequency 1000 Hz
+#define MPU6050_MEASURE_INTERVAL_US 1000 // TODO check setting
+
+namespace DriverFramework
+{
+
+class MPU6050: public ImuSensor
+{
+public:
+	MPU6050(const char *device_path) :
+		ImuSensor(device_path, MPU6050_MEASURE_INTERVAL_US, false), // false = sensor has no mag
+		_last_temp_c(0.0f),
+		_temp_initialized(false)
+	{
+		m_id.dev_id_s.devtype = DRV_DF_DEVTYPE_MPU6050;
+		// TODO: does the WHOAMI make sense as an address?
+		m_id.dev_id_s.address = MPU_WHOAMI_6050;
+	}
+
+	// @return 0 on success, -errno on failure
+	virtual int start();
+
+	// @return 0 on success, -errno on failure
+	virtual int stop();
+
+protected:
+	virtual void _measure();
+	virtual int _publish(struct imu_sensor_data &data);
+
+private:
+	// @returns 0 on success, -errno on failure
+	int mpu6050_init();
+
+	// @returns 0 on success, -errno on failure
+	int mpu6050_deinit();
+
+	// @return the number of FIFO bytes to collect
+	int get_fifo_count();
+
+	void reset_fifo();
+
+	float _last_temp_c;
+	bool _temp_initialized;
+};
+
+}
+// namespace DriverFramework
+

--- a/drivers/mpu6050/test/CMakeLists.txt
+++ b/drivers/mpu6050/test/CMakeLists.txt
@@ -1,0 +1,51 @@
+############################################################################
+#
+# Copyright (C) 2016 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+include_directories(..)
+
+if("${DF_TARGET}" STREQUAL "qurt")
+	# Don't compile for Snapdragon
+else()
+	add_executable(df_mpu6050_test
+		main.cpp
+		test.cpp
+		)
+
+	target_link_libraries(df_mpu6050_test
+		df_driver_framework
+		df_mpu6050
+		${df_link_libs}
+		)
+endif()
+
+# vim: set noet fenc=utf-8 ff=unix ft=cmake :

--- a/drivers/mpu6050/test/main.cpp
+++ b/drivers/mpu6050/test/main.cpp
@@ -1,0 +1,39 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2016 Julian Oes. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+extern int do_test();
+
+int main()
+{
+	return do_test();
+}

--- a/drivers/mpu6050/test/test.cpp
+++ b/drivers/mpu6050/test/test.cpp
@@ -1,0 +1,144 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2016 Julian Oes. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+#include <unistd.h>
+#include "DriverFramework.hpp"
+#include "MPU6050.hpp"
+
+using namespace DriverFramework;
+
+class ImuTester
+{
+public:
+	static const int TEST_PASS = 0;
+	static const int TEST_FAIL = 1;
+
+	static constexpr unsigned num_read_attempts = 1000;
+
+	ImuTester() :
+		m_sensor(IMU_DEVICE_PATH)
+	{}
+
+	static void readSensorCallback(void *arg);
+
+	int run(void);
+
+private:
+	void readSensor();
+	void wait();
+
+	MPU6050		m_sensor;
+	uint32_t	m_read_attempts = 0;
+	uint32_t	m_read_counter = 0;
+
+	int		m_pass;
+	bool		m_done = false;
+};
+
+int ImuTester::run()
+{
+	// Default is fail unless pass critera met
+	m_pass = TEST_FAIL;
+
+	// Register the driver
+	int ret = m_sensor.init();
+
+	// Open the IMU sensor
+	DevHandle h;
+	DevMgr::getHandle(IMU_DEVICE_PATH, h);
+
+	if (!h.isValid()) {
+		DF_LOG_INFO("Error: unable to obtain a valid handle for the receiver at: %s (%d)",
+			    IMU_DEVICE_PATH, h.getError());
+		m_done = true;
+
+	} else {
+		m_done = false;
+	}
+
+	while (!m_done) {
+		++m_read_attempts;
+
+		struct imu_sensor_data data;
+
+		ret = ImuSensor::getSensorData(h, data, true);
+
+		if (ret == 0) {
+			uint32_t count = data.read_counter;
+			DF_LOG_INFO("count: %d", count);
+
+			if (m_read_counter != count) {
+				m_read_counter = count;
+				ImuSensor::printImuValues(h, data);
+			}
+
+		} else {
+			DF_LOG_INFO("error: unable to read the IMU sensor device.");
+		}
+
+		if (m_read_counter >= num_read_attempts) {
+			// Done test - PASSED
+			m_pass = TEST_PASS;
+			m_done = true;
+
+		} else if (m_read_attempts > num_read_attempts) {
+			DF_LOG_INFO("error: unable to read the IMU sensor device.");
+			m_done = true;
+		}
+	}
+
+	DevMgr::releaseHandle(h);
+
+	DF_LOG_INFO("Closing IMU sensor");
+	m_sensor.stop();
+	return m_pass;
+}
+
+int do_test()
+{
+	int ret = Framework::initialize();
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	ImuTester pt;
+
+	DF_LOG_INFO("Run it");
+	ret = pt.run();
+
+	Framework::shutdown();
+
+	DF_LOG_INFO("Test %s", (ret == ImuTester::TEST_PASS) ? "PASSED" : "FAILED");
+	return ret;
+}
+

--- a/framework/include/ImuSensor.hpp
+++ b/framework/include/ImuSensor.hpp
@@ -45,10 +45,10 @@
 #if defined(__QURT)
 #include "dev_fs_lib_spi.h"
 #define IMU_DEVICE_PATH "/dev/spi-1"
-#elif defined(__RPI2)
-#define IMU_DEVICE_PATH "/dev/spidev0.1"
 #elif defined(__BEBOP)
 #define IMU_DEVICE_PATH "/dev/i2c-mpu6050"
+#elif defined(__RPI2)
+#define IMU_DEVICE_PATH "/dev/spidev0.1"
 #else
 #define IMU_DEVICE_PATH "/dev/spidev0.0"
 #endif

--- a/framework/include/ImuSensor.hpp
+++ b/framework/include/ImuSensor.hpp
@@ -35,13 +35,20 @@
 
 #include <stdint.h>
 #include "SyncObj.hpp"
+
+#if defined(__IMU_USE_I2C)
+#include "I2CDevObj.hpp"
+#else
 #include "SPIDevObj.hpp"
+#endif
 
 #if defined(__QURT)
 #include "dev_fs_lib_spi.h"
 #define IMU_DEVICE_PATH "/dev/spi-1"
 #elif defined(__RPI2)
 #define IMU_DEVICE_PATH "/dev/spidev0.1"
+#elif defined(__BEBOP)
+#define IMU_DEVICE_PATH "/dev/i2c-mpu6050"
 #else
 #define IMU_DEVICE_PATH "/dev/spidev0.0"
 #endif
@@ -85,11 +92,19 @@ struct imu_sensor_data {
 	bool		is_last_fifo_sample;
 };
 
+#if defined(__IMU_USE_I2C)
+class ImuSensor : public I2CDevObj
+#else
 class ImuSensor : public SPIDevObj
+#endif
 {
 public:
 	ImuSensor(const char *device_path, unsigned int sample_interval_usec, bool mag_enabled = false) :
+#if defined(__IMU_USE_I2C)
+		I2CDevObj("ImuSensor", device_path, IMU_CLASS_PATH, sample_interval_usec),
+#else
 		SPIDevObj("ImuSensor", device_path, IMU_CLASS_PATH, sample_interval_usec),
+#endif
 		m_mag_enabled(mag_enabled)
 	{}
 

--- a/framework/include/ImuSensor.hpp
+++ b/framework/include/ImuSensor.hpp
@@ -36,7 +36,7 @@
 #include <stdint.h>
 #include "SyncObj.hpp"
 
-#if defined(__IMU_USE_I2C)
+#if defined(__BEBOP)
 #include "I2CDevObj.hpp"
 #else
 #include "SPIDevObj.hpp"
@@ -92,7 +92,7 @@ struct imu_sensor_data {
 	bool		is_last_fifo_sample;
 };
 
-#if defined(__IMU_USE_I2C)
+#if defined(__BEBOP)
 class ImuSensor : public I2CDevObj
 #else
 class ImuSensor : public SPIDevObj
@@ -100,7 +100,7 @@ class ImuSensor : public SPIDevObj
 {
 public:
 	ImuSensor(const char *device_path, unsigned int sample_interval_usec, bool mag_enabled = false) :
-#if defined(__IMU_USE_I2C)
+#if defined(__BEBOP)
 		I2CDevObj("ImuSensor", device_path, IMU_CLASS_PATH, sample_interval_usec),
 #else
 		SPIDevObj("ImuSensor", device_path, IMU_CLASS_PATH, sample_interval_usec),

--- a/framework/include/ImuSensor.hpp
+++ b/framework/include/ImuSensor.hpp
@@ -36,7 +36,7 @@
 #include <stdint.h>
 #include "SyncObj.hpp"
 
-#if defined(__BEBOP)
+#if defined(__IMU_USE_I2C)
 #include "I2CDevObj.hpp"
 #else
 #include "SPIDevObj.hpp"
@@ -92,7 +92,7 @@ struct imu_sensor_data {
 	bool		is_last_fifo_sample;
 };
 
-#if defined(__BEBOP)
+#if defined(__IMU_USE_I2C)
 class ImuSensor : public I2CDevObj
 #else
 class ImuSensor : public SPIDevObj
@@ -100,7 +100,7 @@ class ImuSensor : public SPIDevObj
 {
 public:
 	ImuSensor(const char *device_path, unsigned int sample_interval_usec, bool mag_enabled = false) :
-#if defined(__BEBOP)
+#if defined(__IMU_USE_I2C)
 		I2CDevObj("ImuSensor", device_path, IMU_CLASS_PATH, sample_interval_usec),
 #else
 		SPIDevObj("ImuSensor", device_path, IMU_CLASS_PATH, sample_interval_usec),


### PR DESCRIPTION
This request adds a driver for the IMU-sensor MPU6050 used on the Parrot Bebop 2. As the sensor only supports I2C I had to modify the `framework/include/ImuSensor.hpp` and added a new define which replaces the `SPIDevObj` with an `I2CDevObj`. However, I am a little unsure about the solution. 