### PR TITLE
Fix I2C retries

### DIFF
--- a/framework/include/I2CDevObj.hpp
+++ b/framework/include/I2CDevObj.hpp
@@ -83,7 +83,7 @@ protected:
 			    uint32_t transfer_timeout_usec);
 
 	int m_fd;
-	uint16_t _retries;
+	unsigned _retries;
 };
 
 };

--- a/framework/include/I2CDevObj.hpp
+++ b/framework/include/I2CDevObj.hpp
@@ -57,7 +57,9 @@ class I2CDevObj : public DevObj
 {
 public:
 	I2CDevObj(const char *name, const char *dev_path, const char *dev_class_path, unsigned int sample_interval_usec) :
-		DevObj(name, dev_path, dev_class_path, DeviceBusType_I2C, sample_interval_usec)
+		DevObj(name, dev_path, dev_class_path, DeviceBusType_I2C, sample_interval_usec),
+		m_fd(-1),
+		_retries(0)
 	{
 		m_id.dev_id_s.bus = DeviceBusType_I2C;
 	}


### PR DESCRIPTION
This fixes #119. The `_retries` variable was uninitialized which lead to many retries if unlucky.