### PR TITLE
Move __STDC_FORMAT_MACROS to build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,8 @@ if ("$ENV{CI}")
 	add_definitions(-DCI)
 endif()
 
+add_definitions(-D__STDC_FORMAT_MACROS)
+
 set(df_link_libs CACHE STRING "DF_LINK_LIBS")
 
 # set DF_TARGET

--- a/framework/include/DFLog.hpp
+++ b/framework/include/DFLog.hpp
@@ -35,7 +35,6 @@
 *************************************************************************/
 #pragma once
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
__STDC_FORMAT_MACROS changes the behavior of inttypes.h to allow
defining format macros for printf-like functions. It needs to be defined
before any include is done, otherwise due to include chains and header
guards it may not take effect.

Instead of having to define it everywhere it is used, move the define to the
build system.