### PR TITLE
RPi: just use RPI instead of RPI2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 build_linux
-build_rpi2
+build_rpi
 build_qurt
 build_bebop
 build_edison

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-all: linux qurt rpi2 edison
+all: linux qurt rpi edison
 
 define df_cmake_generate
 mkdir -p build_$(1) && cd build_$(1) && cmake .. -DOS=$(2) -DCMAKE_TOOLCHAIN_FILE=$(3) -DDF_ENABLE_TESTS=1
 endef
 
-rpi2 linux bebop edison:
+rpi linux bebop edison:
 	$(call df_cmake_generate,$@,posix,cmake/toolchains/Toolchain-$@.cmake)
 	cd build_$@ && make
 
@@ -22,6 +22,6 @@ clean:
 	rm -rf build_*
 
 fix-style:
-	@./dspal/tools/fix_code_style.sh -p ".git dspal build_qurt build_linux build_rpi2 build_edison"
+	@./dspal/tools/fix_code_style.sh -p ".git dspal build_qurt build_linux build_rpi build_edison"
 check-style:
-	@./dspal/tools/fix_code_style.sh -p ".git dspal build_qurt build_linux build_rpi2 build_edison" --check
+	@./dspal/tools/fix_code_style.sh -p ".git dspal build_qurt build_linux build_rpi build_edison" --check

--- a/cmake/toolchains/Toolchain-rpi.cmake
+++ b/cmake/toolchains/Toolchain-rpi.cmake
@@ -8,11 +8,11 @@
 #
 ############################################################################
 add_definitions(
-	-D__RPI2
+	-D__RPI
 	-D__LINUX
 )
 
-######### test DriverFramework for rpi2 ###
+######### test DriverFramework for rpi ###
 # used for debug
 #add_definitions(-DDF_DEBUG)
 

--- a/drivers/lsm9ds1/LSM9DS1.hpp
+++ b/drivers/lsm9ds1/LSM9DS1.hpp
@@ -237,7 +237,7 @@ private:
 		int bulkRead(uint8_t address, uint8_t *out_buffer, int length)
 		{
 
-#if defined(__RPI2)
+#if defined(__RPI)
 			return _bulkRead(address | SPI_NO_CS, out_buffer, length);
 #else
 			// Not implemented/tested.

--- a/framework/include/ImuSensor.hpp
+++ b/framework/include/ImuSensor.hpp
@@ -47,7 +47,7 @@
 #define IMU_DEVICE_PATH "/dev/spi-1"
 #elif defined(__BEBOP)
 #define IMU_DEVICE_PATH "/dev/i2c-mpu6050"
-#elif defined(__RPI2)
+#elif defined(__RPI)
 #define IMU_DEVICE_PATH "/dev/spidev0.1"
 #elif defined(__EDISON)
 #define IMU_DEVICE_PATH "/dev/spidev5.1"
@@ -55,7 +55,7 @@
 #define IMU_DEVICE_PATH "/dev/spidev0.0"
 #endif
 
-#if defined(__RPI2)
+#if defined(__RPI)
 #include <linux/spi/spidev.h>
 #define IMU_DEVICE_ACC_GYRO "/dev/spidev0.3"
 #define IMU_DEVICE_MAG "/dev/spidev0.2"

--- a/framework/src/SPIDevObj.cpp
+++ b/framework/src/SPIDevObj.cpp
@@ -39,7 +39,7 @@
 #include "SPIDevObj.hpp"
 #include "DevIOCTL.h"
 
-#if defined(__RPI2) || defined(__EDISON)
+#if defined(__RPI) || defined(__EDISON)
 #include <sys/ioctl.h>
 #include <linux/types.h>
 #include <alloca.h>
@@ -99,7 +99,7 @@ int SPIDevObj::readReg(DevHandle &h, uint8_t address, uint8_t &val)
 
 int SPIDevObj::_readReg(uint8_t address, uint8_t &val)
 {
-#if defined(__RPI2) || defined(__EDISON)
+#if defined(__RPI) || defined(__EDISON)
 	/* implement sensor interface via rpi2 spi */
 	// constexpr int transfer_bytes = 1 + 1; // first byte is address
 	uint8_t write_buffer[2] = {0}; // automatic write buffer
@@ -207,7 +207,7 @@ int SPIDevObj::writeRegVerified(DevHandle &h, uint8_t address, uint8_t val)
 
 int SPIDevObj::_writeReg(uint8_t address, uint8_t val)
 {
-#if defined(__RPI2) || defined(__EDISON)
+#if defined(__RPI) || defined(__EDISON)
 	/* implement sensor interface via rpi2 spi */
 	uint8_t write_buffer[2] = {0}; // automatic write buffer: first byte is address
 	uint8_t read_buffer[2] = {0}; // automatic read buffer
@@ -271,7 +271,7 @@ int SPIDevObj::_modifyReg(uint8_t address, uint8_t clearbits, uint8_t setbits)
 
 int SPIDevObj::bulkRead(DevHandle &h, uint8_t address, uint8_t *out_buffer, int length)
 {
-#if defined(__RPI2) || defined(__EDISON)
+#if defined(__RPI) || defined(__EDISON)
 	/* implement sensor interface via rpi2 spi */
 	SPIDevObj *obj = DevMgr::getDevObjByHandle<SPIDevObj>(h);
 
@@ -311,9 +311,9 @@ int SPIDevObj::bulkRead(DevHandle &h, uint8_t address, uint8_t *out_buffer, int 
 
 int SPIDevObj::_bulkRead(uint8_t address, uint8_t *out_buffer, int length)
 {
-#if defined(__RPI2) || defined(__EDISON)
+#if defined(__RPI) || defined(__EDISON)
 	DF_LOG_DEBUG("_bulkRead: length = %d", length);
-	/* implement sensor interface via rpi2 spi */
+	/* implement sensor interface via rpi spi */
 	int transfer_bytes = 1 + length; // first byte is address
 
 	// automatic write buffer
@@ -387,7 +387,7 @@ int SPIDevObj::_bulkRead(uint8_t address, uint8_t *out_buffer, int length)
 
 int SPIDevObj::setLoopbackMode(DevHandle &h, bool enable)
 {
-#if defined(__RPI2) || defined(__EDISON)
+#if defined(__RPI) || defined(__EDISON)
 	/* implement sensor interface via rpi2 spi */
 	DF_LOG_ERR("ERROR: attempt to set loopback mode in software fails.");
 	return -1;
@@ -404,7 +404,7 @@ int SPIDevObj::setLoopbackMode(DevHandle &h, bool enable)
 
 int SPIDevObj::setBusFrequency(DevHandle &h, SPI_FREQUENCY freq_hz)
 {
-#if defined(__RPI2) || defined(__EDISON)
+#if defined(__RPI) || defined(__EDISON)
 	/* implement sensor interface via rpi2 spi */
 	SPIDevObj *obj = DevMgr::getDevObjByHandle<SPIDevObj>(h);
 
@@ -425,12 +425,12 @@ int SPIDevObj::setBusFrequency(DevHandle &h, SPI_FREQUENCY freq_hz)
 
 int SPIDevObj::_setBusFrequency(SPI_FREQUENCY freq_hz)
 {
-#if defined(__RPI2) || defined(__EDISON)
+#if defined(__RPI) || defined(__EDISON)
 
-	/* implement sensor interface via rpi2 spi */
-	// RPI2 rounds down freq_hz to powers of 2
+	/* implement sensor interface via rpi spi */
+	// RPI rounds down freq_hz to powers of 2
 	// Speeds available: 0.5, 1, 2, 4, 8, 16, and 32 MHz
-	// in-reality 32Mbs is the upper limit of the SPI clock on RPI2.
+	// in-reality 32Mbs is the upper limit of the SPI clock on RPI.
 	switch (freq_hz) {
 	case SPI_FREQUENCY_1MHZ :
 		DF_LOG_DEBUG("SPI speed set to 1MHz.");


### PR DESCRIPTION
The reason is that RPi2 and RPi3 are both compatible.

FYI @mayanez.