### PR TITLE
Add "make load" for qurt platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ helgrind: linux
 clean:
 	rm -rf build_*
 
+load:
+	cd build_qurt && make df_imu_test-load
+
 fix-style:
 	@./dspal/tools/fix_code_style.sh -p ".git dspal build_qurt build_linux build_rpi build_edison"
 check-style:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ helgrind: linux
 clean:
 	rm -rf build_*
 
-load:
+qurt_load: qurt
 	cd build_qurt && make df_imu_test-load
 
 fix-style:


### PR DESCRIPTION
"make load" is a dspal target that projects often have to make it easier to push the images onto the target.