### PR TITLE
MPU9250: correct the interval between samples

### DIFF
--- a/drivers/mpu9250/MPU9250.hpp
+++ b/drivers/mpu9250/MPU9250.hpp
@@ -232,6 +232,7 @@ public:
 		_last_temp_c(0.0f),
 		_temp_initialized(false),
 		_mag_enabled(mag_enabled),
+		_packets_per_cycle_filtered(8.0f), // The FIFO is supposed to run at 8kHz and we sample at 1kHz.
 		_mag(nullptr)
 	{
 		m_id.dev_id_s.devtype = DRV_DF_DEVTYPE_MPU9250;
@@ -282,6 +283,8 @@ private:
 	float _last_temp_c;
 	bool _temp_initialized;
 	bool _mag_enabled;
+	float _packets_per_cycle_filtered;
+
 	MPU9250_mag *_mag;
 };
 


### PR DESCRIPTION
It looks like the FIFO doesn't actually deliver at 8 kHz like it is
supposed to but rather at around 6.7 kHz. Therefore, we shouldn't
blindly pass on an interval matching 8 kHz but should adapt it to the
actual performance.

The rate is additionally filtered to lower jitter because of the fact
that we don't always fetch the same number of samples from the FIFO per
_measure() cycle.

Bench tested on Snappy.

This should fix https://github.com/PX4/Firmware/issues/5110.