### PR TITLE
fix setSampleInterval: release the work handle before re-scheduling

### DIFF
--- a/framework/src/DevObj.cpp
+++ b/framework/src/DevObj.cpp
@@ -322,6 +322,7 @@ void DevObj::setSampleInterval(unsigned int sample_interval_usecs)
 
 		// Reschedule if non-zero and initialized
 		if (m_sample_interval_usecs != 0) {
+			WorkMgr::releaseWorkHandle(m_work_handle);
 			WorkMgr::getWorkHandle(measure, this, m_sample_interval_usecs, m_work_handle);
 			WorkMgr::schedule(m_work_handle);
 		}


### PR DESCRIPTION
When `WorkMgr::getWorkHandle` is reached within `setSampleInterval`, we already have a valid scheduled task, so we need to release it first. Otherwise we end up having two scheduled tasks for the same callback, one with the previous sample interval, and one for the updated.

The faulty behavior can be verified with the accelsim in PX4 (https://github.com/PX4/Firmware/blob/master/src/platforms/posix/drivers/accelsim/accelsim.cpp). It's initialized with a rate of 400Hz and afterwards updates to 800Hz. But the measured update rate of `_measure` is 1200Hz.

@mcharleb maybe there is a better way than to do an expensive rescheduling for just changing the sampling rate?