### PR TITLE
Fixes problems occuring during the execution of the unit test.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ else()
 	include_directories(dspal/include)
 	add_subdirectory(os/qurt)
 	list(APPEND df_link_libs df_qurt_stubs)
+	add_definitions(-D__PX4_QURT)
 
 endif()
 

--- a/drivers/mpu9250/test/test.cpp
+++ b/drivers/mpu9250/test/test.cpp
@@ -83,6 +83,15 @@ int ImuTester::run(unsigned int num_read_attempts)
 		m_done = false;
 	}
 
+	/*
+	 * it would failed when calls MPU9250::start() from DevMgr::getHandle();
+	 * for example, checking MPU9250 WHOAMI register failed.
+	 * mark the error in the h.m_errno in function DevMgr::getHandle() for such case.
+	 * check the h.m_errno if any error happened.
+	 */
+	if (h.getError())
+		m_done = true;
+
 	while (!m_done) {
 		++m_read_attempts;
 
@@ -101,6 +110,11 @@ int ImuTester::run(unsigned int num_read_attempts)
 
 		} else {
 			DF_LOG_INFO("error: unable to read the IMU sensor device.");
+
+#ifdef __PX4_QURT
+			if (ret == ETIMEDOUT)
+				m_done = true;
+#endif
 		}
 
 		if (m_read_counter >= num_read_attempts) {

--- a/framework/include/ImuSensor.hpp
+++ b/framework/include/ImuSensor.hpp
@@ -121,11 +121,24 @@ public:
 			me->m_synchronize.lock();
 
 			if (is_new_data_required) {
+#ifndef __PX4_QURT
 				me->m_synchronize.waitOnSignal(0);
+#else
+				/* When doing IMU sensor unit test, for an unknown reason,
+				 * the Signal never come in case of IMU FIFO corruption
+				 * with a very low reproduce rate.
+				 * set a timeout here to avoid such issue and indicate
+				 * timeout in the return value.
+				 * */
+				ret = me->m_synchronize.waitOnSignal(1000000); // timeout in 1s?
+#endif
 			}
 
 			out_data = me->m_sensor_data;
 			me->m_synchronize.unlock();
+#ifdef __PX4_QURT
+			if (ret != ETIMEDOUT)
+#endif
 			ret = 0;
 		}
 

--- a/framework/src/DevMgr.cpp
+++ b/framework/src/DevMgr.cpp
@@ -231,6 +231,7 @@ DevObj *DevMgr::_getDevObjByHandle(DevHandle &h)
 
 void DevMgr::getHandle(const char *dev_path, DevHandle &h)
 {
+	int err;
 	if (dev_path == nullptr) {
 		h.m_errno = EINVAL;
 		return;
@@ -251,10 +252,11 @@ void DevMgr::getHandle(const char *dev_path, DevHandle &h)
 
 			// Device is registered
 			g_lock_dev_mgr->unlock();
-			list_obj->addHandle(h);
+			err = list_obj->addHandle(h);
 			g_lock_dev_mgr->lock();
 			h.m_handle = list_obj;
-			h.m_errno = 0;
+			if (!err)
+				h.m_errno = 0;
 			break;
 		}
 


### PR DESCRIPTION
df_imu_test module would hang in 20 times loop test. With this patch, no issue was found after 300 times loop test.
 
The fix includes:

1>     The df_imu_test module would not exit if checking the WHOAMI register failed;

2>     The df_imu_test module would not exit if the IMU FIFO corruption happened;

3>     Removing some warning msg from logs which are not for QURT;

The below are the details:

 

1>     The df_imu_test module would not exit if checking the WHOAMI register failed;

        The test would not finish forever, the reproduce rate is about 5%.  This should be a common issue for all platforms.

        The related logs:

[08500/00]  00:56.733  HAP:28754:320745 count: 1000   0095  test.cpp
[08500/00]  00:56.733  HAP:28754:320808 IMU: accel: [0.27, 0.47, 9.84] m/s^2   0143  ImuSensor.hpp
[08500/00]  00:56.733  HAP:28754:320976      gyro:  [-0.01, 0.01, -0.02] rad/s   0147  ImuSensor.hpp
[08500/00]  00:56.735  HAP:28754:321134      mag:  [0.458391, 0.849047, 0.017344] ga   0153  ImuSensor.hpp
[08500/00]  00:56.735  HAP:28754:321312      temp:  53.30 C   0157  ImuSensor.hpp
[08500/00]  00:56.735  HAP:28754:321428 Closing IMU sensor   0119  test.cpp
[08500/00]  00:56.745  HAP:28754:331808 Test PASSED   0140  test.cpp
[08500/00]  00:56.798  HAP:28734:81 Run it   0135  test.cpp
[08500/00]  00:56.798  HAP:28733:18446744073709551544 WARNING: setRealtimeSched failed (not run as root?)   0357  DriverFramework.cpp
[08500/00]  00:56.798  HAP:28734:582 MPU9250 sensor WHOAMI wrong: 0x0, should be: 0x71   0280  MPU9250.cpp


The fix is :  keep the failure result in the h.m_errno when getting the handle, then check it before the test start.

        

-                                              list_obj->addHandle(h);

+                                             err = list_obj->addHandle(h);

                                               g_lock_dev_mgr->lock();

                                               h.m_handle = list_obj;

-                                              h.m_errno = 0;

+                                             if (!err)

+                                                             h.m_errno = 0;

+             /*

+             * it would fail when calls MPU9250::start() from DevMgr::getHandle();

+             * for example, checking MPU9250 WHOAMI register failed.

+             * mark the error in the h.m_errno in function DevMgr::getHandle() for such case.

+             * check the h.m_errno if any error happened.

+             */

+             if (h.getError())

+                             m_done = true;

 

2>     The df_imu_test module would not exit if the IMU FIFO corruption happened;

The test would not finish forever, the reproduce rate is less than 3%.   Not all FIFO corruption would run into this issue. Normally,  the call stacks are when getting the IMU sensor data:

ImuSensor::getSensorData()

me->m_synchronize.waitOnSignal(0);

When the data is ready,  using below method for notification.

m_synchronize.signal();


When the FIFO corruption happens, For a unknown reason, the signal never comes again.

Then df… module would hang.  This should be an QURT related issue.

The related logs:


[08500/00]  14:36.615  HAP:69700:265790 count: 633   0095  test.cpp
[08500/00]  14:36.615  HAP:69700:265855 IMU: accel: [0.83, 0.88, 9.98] m/s^2   0143  ImuSensor.hpp
[08500/00]  14:36.615  HAP:69700:266023      gyro:  [-0.01, 0.00, -0.01] rad/s   0147  ImuSensor.hpp
[08500/00]  14:36.615  HAP:69700:266182      mag:  [0.315820, 0.926396, -0.168234] ga   0153  ImuSensor.hpp
[08500/00]  14:36.615  HAP:69700:266363      temp:  47.10 C   0157  ImuSensor.hpp
[08500/00]  14:36.616  HAP:69700:266666 count: 640   0095  test.cpp
[08500/00]  14:36.616  HAP:69700:266731 IMU: accel: [0.80, 0.76, 9.94] m/s^2   0143  ImuSensor.hpp
[08500/00]  14:36.616  HAP:69700:266906      gyro:  [-0.02, 0.00, -0.02] rad/s   0147  ImuSensor.hpp
[08500/00]  14:36.616  HAP:69700:267053      mag:  [0.315820, 0.926396, -0.168234] ga   0153  ImuSensor.hpp
[08500/00]  14:36.616  HAP:69700:267230      temp:  46.88 C   0157  ImuSensor.hpp
[08500/00]  14:36.617  HAP:69692:267790 FIFO corrupt, temp difference: 11.966759, last temp: 46.966759, current temp: 35.000000   0526  MPU9250.cpp


The fix is to add a timeout instead of infinite waiting.


                                        if (is_new_data_required) {

+#ifndef __PX4_QURT
                                                       me->m_synchronize.waitOnSignal(0);
+#else

+                                                     /* When doing IMU sensor unit test, for an unknown reason,
+                                                     * the Signal never come in case of IMU FIFO corruption
+                                                     * with a very low reproduce rate.
+                                                     * set a timeout here to avoid such issue and indicate
+                                                     * timeout in the return value.
+                                                     * */
+                                                     ret = me->m_synchronize.waitOnSignal(1000000); // timeout in 1s?
+#endif
                                       }
 

3>     Removing some warning msg from logs which are not for QURT

The following logs are not for QURT:


[08500/00]  00:56.798  HAP:28733:18446744073709551544 WARNING: setRealtimeSched failed (not run as root?)   0357  DriverFramework.cpp

Related code:
#ifndef __PX4_QURT

                int ret = setRealtimeSched();
                if (ret != 0) {

                                DF_LOG_ERR("WARNING: setRealtimeSched failed (not run as root?)");

                }

 

#endif


__PX4_QURT is defined when compile the PX4, but not defined when build the DF along. So I add below in the makefile.

                include_directories(dspal/include)
               add_subdirectory(os/qurt)
               list(APPEND df_link_libs df_qurt_stubs)
+             add_definitions(-D__PX4_QURT)
 