### PR TITLE
Fixes problems occuring during the execution of the unit test.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ else()
 	include_directories(dspal/include)
 	add_subdirectory(os/qurt)
 	list(APPEND df_link_libs df_qurt_stubs)
+	add_definitions(-D__PX4_QURT)
 
 endif()
 

--- a/drivers/mpu9250/test/test.cpp
+++ b/drivers/mpu9250/test/test.cpp
@@ -83,6 +83,16 @@ int ImuTester::run(unsigned int num_read_attempts)
 		m_done = false;
 	}
 
+	/*
+	 * it would failed when calls MPU9250::start() from DevMgr::getHandle();
+	 * for example, checking MPU9250 WHOAMI register failed.
+	 * mark the error in the h.m_errno in function DevMgr::getHandle() for such case.
+	 * check the h.m_errno if any error happened.
+	 */
+	if (h.getError()) {
+		m_done = true;
+	}
+
 	while (!m_done) {
 		++m_read_attempts;
 
@@ -101,6 +111,14 @@ int ImuTester::run(unsigned int num_read_attempts)
 
 		} else {
 			DF_LOG_INFO("error: unable to read the IMU sensor device.");
+
+#ifdef __PX4_QURT
+
+			if (ret == ETIMEDOUT) {
+				m_done = true;
+			}
+
+#endif
 		}
 
 		if (m_read_counter >= num_read_attempts) {

--- a/framework/include/ImuSensor.hpp
+++ b/framework/include/ImuSensor.hpp
@@ -121,12 +121,26 @@ public:
 			me->m_synchronize.lock();
 
 			if (is_new_data_required) {
+#ifndef __PX4_QURT
 				me->m_synchronize.waitOnSignal(0);
+#else
+				/* When doing IMU sensor unit test, for an unknown reason,
+				 * the Signal never come in case of IMU FIFO corruption
+				 * with a very low reproduce rate.
+				 * set a timeout here to avoid such issue and indicate
+				 * timeout in the return value.
+				 * */
+				ret = me->m_synchronize.waitOnSignal(1000000); // timeout in 1s?
+#endif
 			}
 
 			out_data = me->m_sensor_data;
 			me->m_synchronize.unlock();
-			ret = 0;
+#ifdef __PX4_QURT
+
+			if (ret != ETIMEDOUT)
+#endif
+				ret = 0;
 		}
 
 		return ret;

--- a/framework/src/DevMgr.cpp
+++ b/framework/src/DevMgr.cpp
@@ -231,6 +231,8 @@ DevObj *DevMgr::_getDevObjByHandle(DevHandle &h)
 
 void DevMgr::getHandle(const char *dev_path, DevHandle &h)
 {
+	int err;
+
 	if (dev_path == nullptr) {
 		h.m_errno = EINVAL;
 		return;
@@ -251,10 +253,14 @@ void DevMgr::getHandle(const char *dev_path, DevHandle &h)
 
 			// Device is registered
 			g_lock_dev_mgr->unlock();
-			list_obj->addHandle(h);
+			err = list_obj->addHandle(h);
 			g_lock_dev_mgr->lock();
 			h.m_handle = list_obj;
-			h.m_errno = 0;
+
+			if (!err) {
+				h.m_errno = 0;
+			}
+
 			break;
 		}
 


### PR DESCRIPTION
df_imu_test module would hang in 20 times loop test. With this patch, no issue was found after 300 times loop test.

The fix includes:

1> The df_imu_test module would not exit if checking the WHOAMI register failed;

2> The df_imu_test module would not exit if the IMU FIFO corruption happened;

3> Removing some warning msg from logs which are not for QURT;