### PR TITLE
LSM9DS1: fix comment about coordinate systems

### DIFF
--- a/drivers/lsm9ds1/LSM9DS1.cpp
+++ b/drivers/lsm9ds1/LSM9DS1.cpp
@@ -400,7 +400,8 @@ void LSM9DS1::_measure()
 		++m_sensor_data.gyro_range_hit_counter;
 	}
 
-	// TODO XXX: Inverting z to make the coordinate system right handed, not sure why this is needed.
+	// Inverting z to make the coordinate system right handed because the
+	// sensors coordinate system is left handed according to the datasheet.
 
 	m_sensor_data.accel_m_s2_x = report.accel_x * _acc_scale;
 	m_sensor_data.accel_m_s2_y = report.accel_y * _acc_scale;


### PR DESCRIPTION
The datasheet is actually correct, so we don't need the confused
comment.

Thanks @kd0aij for raising this in https://github.com/PX4/DriverFramework/commit/6bdc8bce97c619a77276d183f88ee2d6efce4cbf.