### PR TITLE
Use C++ Standard Library header names.

### DIFF
--- a/framework/include/DFLog.hpp
+++ b/framework/include/DFLog.hpp
@@ -50,7 +50,7 @@ uint64_t offsetTime(void);
 
 #ifdef __QURT
 
-#include <stdarg.h>
+#include <cstdarg>
 
 extern "C" {
 


### PR DESCRIPTION
The standard C library headers are deprecated in C++
(see http://en.cppreference.com/w/cpp/header).

The reason for the deprecation being a namespace argument:
in C++ we have namespaces and want everything that is part
of the standard library to be declared in namespace std.

Note that this won't require extra changes to the code, as
everything declared by a C header is also still declared
in the global namespace. For me, it's mostly that it hurts
my eyes to see a C-style header in a C++ program, but the
real benefit would be that you can now make sure you get
the standard function by prepending std:: to things.

Ie, you really need the &lt;cstring&gt; version to do crazy
things like this:

    int main()
    {
        int foo, bar, memcpy = 0;
    
        {
            using std::memcpy;
            memcpy(&foo, &bar, sizeof(int));
        }
    }

This is the second of several commits that prepare for a project-wide
fix of this issue by means of a new script 'Tools/fix_headers.sh' (to
be committed) which will not touch the include in THIS commit because
it is too deep (too far away from the top of the file). Hence the need
for this manual commit for this case.