### PR TITLE
Updating the cmake submodule reference and adding a new bus type.

### DIFF
--- a/framework/include/DevObj.hpp
+++ b/framework/include/DevObj.hpp
@@ -59,6 +59,7 @@ enum DeviceBusType {
 	DeviceBusType_SPI     = 2,
 	DeviceBusType_UAVCAN  = 3,
 	DeviceBusType_VIRT    = 4,
+	DeviceBusType_PHYS    = 5,
 };
 
 /*


### PR DESCRIPTION
The new bus type was added to support the creation of devices that communicate directly with hardware, but do not fit any of the existing bus types.  
