### PR TITLE
Scheduling improvements

### DIFF
--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -43,6 +43,10 @@
 #include "SyncObj.hpp"
 #include "WorkItems.hpp"
 
+#ifdef __DF_LINUX
+#include <sys/prctl.h>
+#endif
+
 // Used for backtrace
 #ifdef DF_ENABLE_BACKTRACE
 #include <stdlib.h>
@@ -357,6 +361,10 @@ void *HRTWorkQueue::process_trampoline(void *arg)
 		DF_LOG_ERR("WARNING: setRealtimeSched failed (not run as root?)");
 	}
 
+#endif
+
+#ifdef __DF_LINUX
+	prctl(PR_SET_NAME, "DFWorker"); //set the thread name
 #endif
 
 	DF_LOG_DEBUG("process_trampoline %d", ret);

--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -471,7 +471,6 @@ void HRTWorkQueue::process(void)
 {
 	DF_LOG_DEBUG("HRTWorkQueue::process");
 	uint64_t next;
-	timespec ts;
 	uint64_t now;
 
 	while (g_run_status && g_run_status->check()) {
@@ -485,19 +484,8 @@ void HRTWorkQueue::process(void)
 		now = offsetTime();
 		DF_LOG_DEBUG("now=%" PRIu64, now);
 
-#ifdef __DF_LINUX
-		// This offset removes latency in processing the items on the queue
-		uint64_t TUNING_ADJUSTMENT = 150;
-		next -= TUNING_ADJUSTMENT;
-#endif
-
-		uint64_t wait_time_usec = (next > now) ? next - now : 0;
-
-		// Wait granularity is 200us
-		// TODO: this magic number needs checking
-		if (wait_time_usec > 200) {
-			// pthread_cond_timedwait uses absolute time
-			ts = offsetTimeToAbsoluteTime(next);
+		if (next > now) {
+			uint64_t wait_time_usec = next - now;
 
 			DF_LOG_DEBUG("HRTWorkQueue::process waiting for work (%" PRIi64 "usec)", wait_time_usec);
 			// Wait until next expiry or until a new item is rescheduled

--- a/framework/src/WorkItems.cpp
+++ b/framework/src/WorkItems.cpp
@@ -161,29 +161,39 @@ int WorkItems::_schedule(int index)
 					if (wi->m_in_use) {
 						if (wi->m_delay_usec == item->m_delay_usec) {
 							queue_time_equal = wi->m_queue_time;
+
 						} else if (item->m_delay_usec % wi->m_delay_usec == 0) {
 							queue_time_multiple = wi->m_queue_time;
+
 						} else if (wi->m_delay_usec % item->m_delay_usec == 0) {
 							queue_time_divider = wi->m_queue_time;
+
 						} else {
 							queue_time_other = wi->m_queue_time;
 						}
 					}
+
 					idx = m_work_items.next(idx);
 				}
 
 				uint64_t now = offsetTime();
+
 				if (queue_time_equal) {
 					item->m_queue_time = queue_time_equal;
+
 				} else if (queue_time_multiple) {
 					item->m_queue_time = queue_time_multiple;
+
 				} else if (queue_time_divider) {
 					item->m_queue_time = queue_time_divider;
+
 				} else if (queue_time_other) {
 					item->m_queue_time = queue_time_other;
+
 				} else {
 					item->m_queue_time = now;
 				}
+
 				// make sure next scheduling is in the future
 				while (item->m_queue_time + item->m_delay_usec < now) {
 					item->m_queue_time += item->m_delay_usec;
@@ -324,34 +334,42 @@ void WorkItems::_processExpiredWorkItems(uint64_t &next)
 
 #if 0 //debug the scheduling adjustment
 	static int no_work_counter = 0;
+
 	if (had_work) {
 		static uint32_t max_late_stat = max_too_late_scheduled;
 		static uint64_t max_late_sum = 0;
 		static int counter = 0;
+
 		if (max_too_late_scheduled > max_late_stat) {
 			max_late_stat = max_too_late_scheduled;
 		}
+
 		max_late_sum += max_too_late_scheduled;
+
 		if (++counter == 200) {
 			DF_LOG_ERR("max late= %3i us mean late=%3i us  no work=%i, cur_adj=%i",
-					(int)max_late_stat, (int)(max_late_sum/counter), no_work_counter, m_scheduling_adjustment);
+				   (int)max_late_stat, (int)(max_late_sum / counter), no_work_counter, m_scheduling_adjustment);
 			counter = 0;
 			max_late_stat = 0;
 			no_work_counter = 0;
 			max_late_sum = 0;
 		}
+
 	} else {
 		++no_work_counter;
 	}
+
 #endif
 
 	if (had_work) {
 		// Scheduling can have jitter, so adjust only by a fraction.
 		// The chosen factors are a tradeoff between low-latency and CPU overhead
 		m_scheduling_adjustment += max_too_late_scheduled / 5;
+
 		if (m_scheduling_adjustment > 1e4) { //max to 10ms
 			m_scheduling_adjustment = 1e4;
 		}
+
 	} else {
 		// We woke up for nothing. Reduce the adjustment
 		m_scheduling_adjustment = m_scheduling_adjustment * 90 / 100;

--- a/framework/src/WorkItems.cpp
+++ b/framework/src/WorkItems.cpp
@@ -361,6 +361,10 @@ void WorkItems::_processExpiredWorkItems(uint64_t &next)
 
 #endif
 
+// disable scheduling adjustment on embedded platforms (tests showed worse performance on RPI with this,
+// but other platforms should be tested as well)
+#if defined(__DF_LINUX) && !defined(__DF_RPI) && !defined(__DF_BEBOP) && !defined(__DF_EDISON)
+
 	if (had_work) {
 		// Scheduling can have jitter, so adjust only by a fraction.
 		// The chosen factors are a tradeoff between low-latency and CPU overhead
@@ -376,6 +380,7 @@ void WorkItems::_processExpiredWorkItems(uint64_t &next)
 	}
 
 	next -= m_scheduling_adjustment;
+#endif
 
 	DF_LOG_DEBUG("Setting next=%" PRIu64, next);
 }

--- a/framework/src/WorkItems.cpp
+++ b/framework/src/WorkItems.cpp
@@ -58,6 +58,7 @@ bool WorkItems::_isValidIndex(int index)
 
 void WorkItems::WorkItem::updateStats(unsigned int cur_usec)
 {
+#if SHOW_STATS == 1
 	unsigned long delay_usec = (m_last == ~0x0UL) ? (cur_usec - m_queue_time) : (cur_usec - m_last);
 
 	if (delay_usec < m_min) {
@@ -72,7 +73,6 @@ void WorkItems::WorkItem::updateStats(unsigned int cur_usec)
 	m_count += 1;
 	m_last = cur_usec;
 
-#if SHOW_STATS == 1
 
 	if ((m_count % 100) == 99) {
 		dumpStats();
@@ -83,17 +83,21 @@ void WorkItems::WorkItem::updateStats(unsigned int cur_usec)
 
 void WorkItems::WorkItem::resetStats()
 {
+#if SHOW_STATS == 1
 	m_last = ~(unsigned long)0;
 	m_min = ~(unsigned long)0;
 	m_max = 0;
 	m_total = 0;
 	m_count = 0;
+#endif
 }
 
 void WorkItems::WorkItem::dumpStats()
 {
+#if SHOW_STATS == 1
 	DF_LOG_DEBUG("Stats for callback=%p: count=%lu, avg=%lu min=%lu max=%lu",
 		     m_callback, m_count, m_total / m_count, m_min, m_max);
+#endif
 }
 
 void WorkItems::finalize()

--- a/framework/src/WorkItems.cpp
+++ b/framework/src/WorkItems.cpp
@@ -361,8 +361,8 @@ void WorkItems::_processExpiredWorkItems(uint64_t &next)
 
 #endif
 
-// disable scheduling adjustment on embedded platforms (tests showed worse performance on RPI with this,
-// but other platforms should be tested as well)
+// disable scheduling adjustment on embedded platforms (tests showed worse performance on RPI & QuRT with this)
+// see test results: https://github.com/PX4/DriverFramework/pull/155
 #if defined(__DF_LINUX) && !defined(__DF_RPI) && !defined(__DF_BEBOP) && !defined(__DF_EDISON)
 
 	if (had_work) {

--- a/framework/src/WorkItems.hpp
+++ b/framework/src/WorkItems.hpp
@@ -151,6 +151,7 @@ private:
 	DFUIntList		m_work_list; 	// List of active work items
 	DFManagedList<WorkItem> m_work_items;	// List of all created work items
 	SyncObj			m_lock;
+	uint32_t		m_scheduling_adjustment = 0; // dynamic adjustment to account for scheduling overhead
 };
 
 class RunStatus

--- a/framework/src/WorkItems.hpp
+++ b/framework/src/WorkItems.hpp
@@ -89,7 +89,7 @@ private:
 		~WorkItem() {}
 
 		void schedule();
-		void updateStats(unsigned int cur_usec);
+		inline void updateStats(unsigned int cur_usec);
 		void resetStats();
 		void dumpStats();
 
@@ -110,12 +110,14 @@ private:
 		uint32_t	m_delay_usec;
 		//WorkHandle 	m_handle;
 
+#if SHOW_STATS == 1
 		// statistics
 		unsigned long 	m_last;
 		unsigned long 	m_min;
 		unsigned long 	m_max;
 		unsigned long 	m_total;
 		unsigned long 	m_count;
+#endif
 
 		bool		m_in_use = false;
 


### PR DESCRIPTION
This PR has 2 parts:
## Align scheduling of different items

Reduces scheduling overhead such that the scheduling thread has to wake up less often and can process as many items as possible at once.
Also makes the scheduling (or rather the wakeup times) more deterministic.

On RPi this reduces the CPU load by ~4%.
## Estimate the scheduling overhead and dynamically adjust sleeping time

The hardcoded `TUNING_ADJUSTMENT` needed roughly 5% CPU time on my laptop (15% vs. 20% running PX4 SITL). The changes here remove this overhead while still adapting to the scheduling overhead.
I added some debug output to measure the impacts of the changes. This is before, with TUNING_ADJUSTMENT:

```
34414773 max late=  24 us mean late=  1 us  no work=3509, cur_adj=0
34702763 max late=  46 us mean late=  1 us  no work=3644, cur_adj=0
34982768 max late=  28 us mean late=  2 us  no work=3492, cur_adj=0
35262766 max late=  38 us mean late=  1 us  no work=3283, cur_adj=0
35530766 max late=  19 us mean late=  1 us  no work=3339, cur_adj=0
35804762 max late=  36 us mean late=  1 us  no work=3355, cur_adj=0
36080765 max late=  20 us mean late=  1 us  no work=3369, cur_adj=0
36346764 max late=  22 us mean late=  1 us  no work=3244, cur_adj=0
36626765 max late=  53 us mean late=  2 us  no work=3376, cur_adj=0
36918761 max late=  16 us mean late=  1 us  no work=3746, cur_adj=0
```

The first column shows by how much we scheduled an item too late at maximum, then the mean, then the number of scheduling wakeups without any work to do, and the current scheduling adjustment. The numbers are taken over 200 scheduled items. So here we woke up roughly 16 times between 2 schedulings which had actual work to do.

![prev_tuning_150](https://cloud.githubusercontent.com/assets/281593/19144544/72d01408-8baa-11e6-8031-ba903ba5d6e4.png)

whitout tuning adjustment:

```
20577938 max late = 102 us mean= 69 us  no work=0, cur_adj=10000
20977884 max late = 128 us mean= 67 us  no work=0, cur_adj=10000
21377905 max late = 137 us mean= 60 us  no work=0, cur_adj=10000
21777881 max late = 106 us mean= 60 us  no work=0, cur_adj=10000
22177895 max late = 115 us mean= 58 us  no work=0, cur_adj=10000
22577889 max late = 147 us mean= 60 us  no work=0, cur_adj=10000
22977890 max late = 161 us mean= 61 us  no work=0, cur_adj=10000
23377908 max late = 104 us mean= 73 us  no work=0, cur_adj=10000
```

![prev_no_tuning](https://cloud.githubusercontent.com/assets/281593/19144549/7d3849d8-8baa-11e6-9f47-2b75f1739fde.png)

This PR:

```
42479683 max late=  52 us mean late= 10 us  no work=100, cur_adj=74
42831695 max late=  54 us mean late= 10 us  no work=92, cur_adj=75
43201716 max late=  52 us mean late= 11 us  no work=113, cur_adj=51
43569715 max late=  62 us mean late= 10 us  no work=108, cur_adj=55
43919691 max late=  68 us mean late= 11 us  no work=95, cur_adj=71
44279687 max late=  53 us mean late= 11 us  no work=105, cur_adj=56
44645680 max late=  55 us mean late=  9 us  no work=86, cur_adj=72
45009722 max late=  75 us mean late= 11 us  no work=116, cur_adj=73
45375680 max late=  47 us mean late= 10 us  no work=105, cur_adj=56
45733684 max late=  48 us mean late= 10 us  no work=109, cur_adj=57
46095714 max late=  51 us mean late=  9 us  no work=92, cur_adj=53
46449702 max late=  56 us mean late=  9 us  no work=96, cur_adj=62
46821689 max late=  55 us mean late= 10 us  no work=100, cur_adj=67
47163697 max late=  53 us mean late= 10 us  no work=92, cur_adj=64
```

It can be seen that the mean is reduced, but without sacrificing performance.

![dynamic_adjust_5_95](https://cloud.githubusercontent.com/assets/281593/19144552/87eebf7e-8baa-11e6-92cc-5291e75d97ef.png)

As a comparison, this is on Pixracer (DF not used)
![nuttx_pixracer](https://cloud.githubusercontent.com/assets/281593/19144236/b182a69a-8ba8-11e6-8d5d-b04744351c1e.png)
### on the Raspberry Pi

Neither the TUNING_ADJUSTMENT nor dynamic adjustment help here. Not quite sure, but I think it's because of the following reasons:
- the CPU runs slower, thus a single scheduling execution without work will delay the next execution
- as it needs more execution time, the chance is higher to be interrupted by a higher priority thread.

without adjustment:
![prev_no_tuning_zoom_out2](https://cloud.githubusercontent.com/assets/281593/19145778/e07b4b5c-8bb0-11e6-93de-f9cc15efbd20.png)
dynamic adjustment (it's even worse with TUNING_ADJUSTMENT):
![adjust_5_90_zoom_out2](https://cloud.githubusercontent.com/assets/281593/19145805/fc3efaa0-8bb0-11e6-9d53-843763144a9b.png)

For now, I only enabled the adjustment on non-embedded linux platforms (requires #150).

I'd be interested to see the performance comparison on other platforms, like QuRT & Bebop.
