### PR TITLE
LSM9DS1: fix mag coordinate

### DIFF
--- a/drivers/lsm9ds1/LSM9DS1.cpp
+++ b/drivers/lsm9ds1/LSM9DS1.cpp
@@ -412,7 +412,7 @@ void LSM9DS1::_measure()
 	m_sensor_data.gyro_rad_s_y = float(report.gyro_y) * _gyro_scale;
 	m_sensor_data.gyro_rad_s_z = -float(report.gyro_z) * _gyro_scale;
 
-	m_sensor_data.mag_ga_x = float(report.mag_x) * _mag_scale;
+	m_sensor_data.mag_ga_x = -float(report.mag_x) * _mag_scale;
 	m_sensor_data.mag_ga_y = float(report.mag_y) * _mag_scale;
 	m_sensor_data.mag_ga_z = -float(report.mag_z) * _mag_scale;
 


### PR DESCRIPTION
sensor coordinate system of mag is different with others. MAG_X should be -MAG_X
http://www.st.com/content/ccc/resource/technical/document/datasheet/1e/3f/2a/d6/25/eb/48/46/DM00103319.pdf/files/DM00103319.pdf/jcr:content/translations/en.DM00103319.pdf 
page 10.