### PR TITLE
Fix BMP280 calibration according to datasheet

### DIFF
--- a/drivers/bmp280/BMP280.cpp
+++ b/drivers/bmp280/BMP280.cpp
@@ -57,7 +57,7 @@ using namespace DriverFramework;
 
 // convertPressure must be called after convertTemperature
 // as convertTemperature sets m_sensor_data.t_fine
-int64_t BMP280::convertPressure(int64_t adc_P)
+uint32_t BMP280::convertPressure(int64_t adc_P)
 {
 	int64_t var1, var2, p;
 	var1 = ((int64_t) m_sensor_data.t_fine) - 128000;
@@ -78,7 +78,7 @@ int64_t BMP280::convertPressure(int64_t adc_P)
 	var2 = (((int64_t) m_sensor_calibration.dig_P8) * p) >> 19;
 	p = ((p + var1 + var2) >> 8) + (((int64_t) m_sensor_calibration.dig_P7) << 4);
 
-	return p;
+	return (uint32_t)p;
 }
 
 int32_t BMP280::convertTemperature(int32_t adc_T)

--- a/drivers/bmp280/BMP280.cpp
+++ b/drivers/bmp280/BMP280.cpp
@@ -278,8 +278,8 @@ void BMP280::_measure(void)
 
 	m_synchronize.lock();
 
-	m_sensor_data.pressure_pa = convertPressure(pressure_from_sensor) / 256.0;
 	m_sensor_data.temperature_c = convertTemperature(temperature_from_sensor) / 100.0;
+	m_sensor_data.pressure_pa = convertPressure(pressure_from_sensor) / 256.0;
 	m_sensor_data.last_read_time_usec = DriverFramework::offsetTime();
 	m_sensor_data.read_counter++;
 

--- a/drivers/bmp280/BMP280.hpp
+++ b/drivers/bmp280/BMP280.hpp
@@ -96,7 +96,7 @@ private:
 	// Q24.8 format (24 integer bits and 8 fractional bits)
 	// Output value of “24674867” represents
 	// 24674867/256 = 96386.2 Pa = 963.862 hPa
-	int64_t convertPressure(int64_t adc_pressure);
+	uint32_t convertPressure(int64_t adc_pressure);
 
 	// Returns temperature in DegC, resolution is 0.01 DegC
 	// Output value of “5123” equals 51.23 DegC


### PR DESCRIPTION
This is what @langxm1223 suggested a while ago in https://github.com/PX4/Firmware/issues/5243.

The changes are according to the datasheet.

This closes https://github.com/PX4/Firmware/issues/5243.