### PR TITLE
Fix the MPU9250_WHOAMI verification AND fixed the imusensor macro definition.

### DIFF
--- a/drivers/mpu9250/MPU9250.cpp
+++ b/drivers/mpu9250/MPU9250.cpp
@@ -275,7 +275,7 @@ int MPU9250::start()
 		goto exit;
 	}
 
-	if (MPU_WHOAMI_9250 != sensor_id && MPU_WHOAMI_9250_REAL != sensor_id)) {
+	if (MPU_WHOAMI_9250 != sensor_id && MPU_WHOAMI_9250_REAL != sensor_id) {
 		DF_LOG_ERR("MPU9250 sensor WHOAMI wrong: 0x%X, should be: 0x%X",
 			   sensor_id, MPU_WHOAMI_9250);
 		result = -1;

--- a/drivers/mpu9250/MPU9250.cpp
+++ b/drivers/mpu9250/MPU9250.cpp
@@ -275,9 +275,9 @@ int MPU9250::start()
 		goto exit;
 	}
 
-	if (!( MPU_WHOAMI_9250==sensor_id || MPU_WHOAMI_9250_REAL==sensor_id)) {
+	if (!(MPU_WHOAMI_9250 == sensor_id || MPU_WHOAMI_9250_REAL == sensor_id)) {
 		DF_LOG_ERR("MPU9250 sensor WHOAMI wrong: 0x%X, should be: 0x%X OR 0x%X",
-			   sensor_id, MPU_WHOAMI_9250,MPU_WHOAMI_9250_REAL);
+			   sensor_id, MPU_WHOAMI_9250, MPU_WHOAMI_9250_REAL);
 		result = -1;
 		goto exit;
 	}

--- a/drivers/mpu9250/MPU9250.cpp
+++ b/drivers/mpu9250/MPU9250.cpp
@@ -275,9 +275,9 @@ int MPU9250::start()
 		goto exit;
 	}
 
-	if (sensor_id != MPU_WHOAMI_9250) {
-		DF_LOG_ERR("MPU9250 sensor WHOAMI wrong: 0x%X, should be: 0x%X",
-			   sensor_id, MPU_WHOAMI_9250);
+	if (!( MPU_WHOAMI_9250==sensor_id || MPU_WHOAMI_9250_REAL==sensor_id)) {
+		DF_LOG_ERR("MPU9250 sensor WHOAMI wrong: 0x%X, should be: 0x%X OR 0x%X",
+			   sensor_id, MPU_WHOAMI_9250,MPU_WHOAMI_9250_REAL);
 		result = -1;
 		goto exit;
 	}

--- a/drivers/mpu9250/MPU9250.cpp
+++ b/drivers/mpu9250/MPU9250.cpp
@@ -275,9 +275,9 @@ int MPU9250::start()
 		goto exit;
 	}
 
-	if (!(MPU_WHOAMI_9250 == sensor_id || MPU_WHOAMI_9250_REAL == sensor_id)) {
-		DF_LOG_ERR("MPU9250 sensor WHOAMI wrong: 0x%X, should be: 0x%X OR 0x%X",
-			   sensor_id, MPU_WHOAMI_9250, MPU_WHOAMI_9250_REAL);
+	if (MPU_WHOAMI_9250 != sensor_id && MPU_WHOAMI_9250_REAL != sensor_id)) {
+		DF_LOG_ERR("MPU9250 sensor WHOAMI wrong: 0x%X, should be: 0x%X",
+			   sensor_id, MPU_WHOAMI_9250);
 		result = -1;
 		goto exit;
 	}
@@ -285,14 +285,14 @@ int MPU9250::start()
 	result = mpu9250_init();
 
 	if (result != 0) {
-		DF_LOG_ERR("error: IMU sensor initialization failed, sensor read thread not started");
+	DF_LOG_ERR("error: IMU sensor initialization failed, sensor read thread not started");
 		goto exit;
 	}
 
 	result = DevObj::start();
 
 	if (result != 0) {
-		DF_LOG_ERR("DevObj start failed");
+	DF_LOG_ERR("DevObj start failed");
 		return result;
 	}
 

--- a/drivers/mpu9250/MPU9250.cpp
+++ b/drivers/mpu9250/MPU9250.cpp
@@ -285,14 +285,14 @@ int MPU9250::start()
 	result = mpu9250_init();
 
 	if (result != 0) {
-	DF_LOG_ERR("error: IMU sensor initialization failed, sensor read thread not started");
+		DF_LOG_ERR("error: IMU sensor initialization failed, sensor read thread not started");
 		goto exit;
 	}
 
 	result = DevObj::start();
 
 	if (result != 0) {
-	DF_LOG_ERR("DevObj start failed");
+		DF_LOG_ERR("DevObj start failed");
 		return result;
 	}
 

--- a/drivers/mpu9250/MPU9250.hpp
+++ b/drivers/mpu9250/MPU9250.hpp
@@ -193,6 +193,7 @@ namespace DriverFramework
 #define DRV_DF_DEVTYPE_MPU9250 0x41
 
 #define MPU_WHOAMI_9250			0x71
+#define MPU_WHOAMI_9250_REAL		0x73
 
 #pragma pack(push, 1)
 struct fifo_packet {
@@ -299,4 +300,3 @@ private:
 
 }
 // namespace DriverFramework
-

--- a/framework/include/ImuSensor.hpp
+++ b/framework/include/ImuSensor.hpp
@@ -59,6 +59,9 @@
 #include <linux/spi/spidev.h>
 #define IMU_DEVICE_ACC_GYRO "/dev/spidev0.3"
 #define IMU_DEVICE_MAG "/dev/spidev0.2"
+#elif defined(__DF_RPI_SINGLE)
+#define IMU_DEVICE_ACC_GYRO "/dev/spidev0.1"
+#define IMU_DEVICE_MAG "/dev/spidev0.1"
 #else
 #define IMU_DEVICE_ACC_GYRO ""
 #define IMU_DEVICE_MAG ""


### PR DESCRIPTION
Change  sensor_id verification,both 0x71 and 0x73 are valid.
There are various kind of mpu9250 module in China.
The WHOAMI value of the MPU9250 sensor which I used  was 0x73.
I don't know why there are different WHOAMI values of them.
So I add the 0x73 support into the code.

I use the rpi to build the autopilot without pxfmini or navio.
Pxfmini and navio was not popular in China. I can hardly to purchase it.
So I use raspberry pi separately.
If use raspberry pi separately
and communicate with  MPU9250 sensor by SPI mode 
both IMU_DEVICE_ACC_GYRO and  IMU_DEVICE_MAG  should be defined as
"/dev/spidev0.1"(if you plug the sensor to spidev0.1),other wise the px4firmware can't work correctly.



