### PR TITLE
Add Support for Aerotenna OcPoC Hardware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ define df_cmake_generate
 mkdir -p build_$(1) && cd build_$(1) && cmake .. -DOS=$(2) -DCMAKE_TOOLCHAIN_FILE=$(3) -DDF_ENABLE_TESTS=1 $(4)
 endef
 
-rpi linux bebop edison:
+rpi linux bebop edison ocpoc:
 	$(call df_cmake_generate,$@,posix,cmake/toolchains/Toolchain-$@.cmake,)
 	cd build_$@ && make
 

--- a/cmake/toolchains/Toolchain-ocpoc.cmake
+++ b/cmake/toolchains/Toolchain-ocpoc.cmake
@@ -1,0 +1,43 @@
+############################################################################
+# Cross-compilation Toolchain File (CMAKE_TOOLCHAIN_FILE)
+# for OcPoC-Zynq-Mini
+# 
+# Requires Xilinx petalinux-v2015.4-final. Define an $ENV variable by adding
+# the following line to .bashrc:
+# export OCPOC_TOOLCHAIN_DIR="<path_to_petalinux>/petalinux-v2015.4-final/tools/linux-i386/arm-xilinx-linux-gnueabi/bin"
+#
+# Author: Dave Royer (dave@aerotenna.com)
+#
+############################################################################
+add_definitions(
+	-D__DF_OCPOC
+	-D__DF_LINUX
+)
+
+set(DF_TARGET ocpoc)
+
+# See notes above for setting the ENV variable in .bashrc
+if ("$ENV{OCPOC_TOOLCHAIN_DIR}" STREQUAL "")
+        message(FATAL_ERROR "$OCPOC_TOOLCHAIN_DIR not set")
+else()
+        set(OCPOC_TOOLCHAIN_DIR $ENV{OCPOC_TOOLCHAIN_DIR})
+endif()
+
+# this one is important
+set(CMAKE_SYSTEM_NAME Generic)
+
+# this one not so much
+set(CMAKE_SYSTEM_VERSION 1)
+
+# set cross compilers
+set(CMAKE_C_COMPILER "${OCPOC_TOOLCHAIN_DIR}/arm-xilinx-linux-gnueabi-gcc")
+set(CMAKE_CXX_COMPILER "${OCPOC_TOOLCHAIN_DIR}/arm-xilinx-linux-gnueabi-g++")
+set(CMAKE_C_FLAGS "")
+set(LINKER_FLAGS "-Wl,-gc-sections")
+set(CMAKE_EXE_LINKER_FLAGS ${LINKER_FLAGS})
+
+# search for programs in the build host directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# for libraries and headers in the target directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/drivers/bmp280/CMakeLists.txt
+++ b/drivers/bmp280/CMakeLists.txt
@@ -35,13 +35,15 @@ include(../../cmake/df_common.cmake)
 
 include_directories(../../framework/include)
 
-get_filename_component(drivername ${CMAKE_CURRENT_SOURCE_DIR} NAME)
-df_add_library(df_${drivername}
-	BMP280.cpp
-	)
+if("${DF_TARGET}" STREQUAL "ocpoc")
+else()
+	get_filename_component(drivername ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+	df_add_library(df_${drivername}
+		BMP280.cpp
+		)
 
-if("${DF_ENABLE_TESTS}" STREQUAL "1")
-	add_subdirectory(test)
+	if("${DF_ENABLE_TESTS}" STREQUAL "1")
+		add_subdirectory(test)
+	endif()
 endif()
-
 # vim: set noet fenc=utf-8 ff=unix ft=cmake :

--- a/drivers/hmc5883/HMC5883.hpp
+++ b/drivers/hmc5883/HMC5883.hpp
@@ -38,9 +38,9 @@
 namespace DriverFramework
 {
 #if defined(__DF_OCPOC)
-  #define MAG_DEVICE_PATH "/dev/i2c-0"
+#define MAG_DEVICE_PATH "/dev/i2c-0"
 #else
-  #define MAG_DEVICE_PATH "/dev/iic-2"
+#define MAG_DEVICE_PATH "/dev/iic-2"
 #endif
 
 // 150 Hz (supported in single measurment mode is up to 160 Hz

--- a/drivers/hmc5883/HMC5883.hpp
+++ b/drivers/hmc5883/HMC5883.hpp
@@ -37,8 +37,11 @@
 
 namespace DriverFramework
 {
-
-#define MAG_DEVICE_PATH "/dev/iic-2"
+#if defined(__DF_OCPOC)
+  #define MAG_DEVICE_PATH "/dev/i2c-0"
+#else
+  #define MAG_DEVICE_PATH "/dev/iic-2"
+#endif
 
 // 150 Hz (supported in single measurment mode is up to 160 Hz
 #define HMC5883_MEASURE_INTERVAL_US (1000000/150)

--- a/drivers/ms5611/MS5611.cpp
+++ b/drivers/ms5611/MS5611.cpp
@@ -171,7 +171,7 @@ int MS5611::loadCalibration()
 	for (int i = 0; i < 8; ++i) {
 		uint8_t cmd = ADDR_PROM_SETUP + (i * 2);
 
-#if defined(__DF_OCPOC)
+#if defined(__BARO_USE_SPI)
 		if (_bulkRead(cmd, &prom_buf[0], 2) < 0) {
 #else
 		_retries = 5;
@@ -218,7 +218,7 @@ int MS5611::ms5611_init()
 	m_sensor_data.error_counter = 0;
 	m_synchronize.unlock();
 
-#if defined(__DF_OCPOC)
+#if defined(__BARO_USE_SPI)
 	int result = _setBusFrequency(SPI_FREQUENCY_1MHZ);
 #else
 	int result = _setSlaveConfig(MS5611_SLAVE_ADDRESS,
@@ -259,7 +259,7 @@ int MS5611::reset()
 	int result;
 	uint8_t cmd = ADDR_RESET_CMD;
 
-#if defined(__DF_OCPOC)
+#if defined(__BARO_USE_SPI)
 	uint8_t wbuf[1];
 	uint8_t rbuf[1];
 	wbuf[0] = cmd;
@@ -284,7 +284,7 @@ int MS5611::start()
 {
 	int result = 0;
 
-#if defined(__DF_OCPOC)
+#if defined(__BARO_USE_SPI)
 	result = SPIDevObj::start();
 #else
 	result = I2CDevObj::start();
@@ -331,7 +331,7 @@ int MS5611::_request(uint8_t cmd)
 {
 	int ret;
 
-#if defined(__DF_OCPOC)
+#if defined(__BARO_USE_SPI)
 	uint8_t wbuf[1];
 	uint8_t rbuf[1];
 
@@ -360,7 +360,7 @@ int MS5611::_collect(uint32_t &raw)
 
 	uint8_t cmd = ADDR_CMD_ADC_READ;
 
-#if defined(__DF_OCPOC)
+#if defined(__BARO_USE_SPI)
 	uint8_t buf[4];
 	uint8_t wbuf[4];
 	wbuf[0] = cmd;

--- a/drivers/ms5611/MS5611.cpp
+++ b/drivers/ms5611/MS5611.cpp
@@ -171,9 +171,12 @@ int MS5611::loadCalibration()
 	for (int i = 0; i < 8; ++i) {
 		uint8_t cmd = ADDR_PROM_SETUP + (i * 2);
 
+#if defined(__DF_OCPOC)
+		if (_bulkRead(cmd, &prom_buf[0], 2) < 0) {
+#else
 		_retries = 5;
-
 		if (_readReg(cmd, &prom_buf[0], 2) < 0) {
+#endif
 			DF_LOG_ERR("Read calibration error");
 			break;
 		}
@@ -215,9 +218,13 @@ int MS5611::ms5611_init()
 	m_sensor_data.error_counter = 0;
 	m_synchronize.unlock();
 
+#if defined(__DF_OCPOC)
+	int result = _setBusFrequency(SPI_FREQUENCY_1MHZ);
+#else
 	int result = _setSlaveConfig(MS5611_SLAVE_ADDRESS,
 				     MS5611_BUS_FREQUENCY_IN_KHZ,
 				     MS5611_TRANSFER_TIMEOUT_IN_USECS);
+#endif
 
 	if (result < 0) {
 		DF_LOG_ERR("could not set slave config");
@@ -251,8 +258,19 @@ int MS5611::reset()
 {
 	int result;
 	uint8_t cmd = ADDR_RESET_CMD;
+
+#if defined(__DF_OCPOC)
+	uint8_t wbuf[1];
+	uint8_t rbuf[1];
+	wbuf[0] = cmd;
+	result = _transfer(wbuf, rbuf, 1);
+
+#else
+
 	_retries = 10;
 	result = _writeReg(cmd, nullptr, 0);
+
+#endif
 
 	if (result < 0) {
 		DF_LOG_ERR("Unable to reset device: %d", result);
@@ -266,7 +284,11 @@ int MS5611::start()
 {
 	int result = 0;
 
+#if defined(__DF_OCPOC)
+	result = SPIDevObj::start();
+#else
 	result = I2CDevObj::start();
+#endif
 
 	if (result != 0) {
 		DF_LOG_ERR("error: could not start DevObj");
@@ -309,8 +331,16 @@ int MS5611::_request(uint8_t cmd)
 {
 	int ret;
 
+#if defined(__DF_OCPOC)
+	uint8_t wbuf[1];
+	uint8_t rbuf[1];
+
+	wbuf[0] = cmd;
+	ret = _transfer(wbuf, rbuf, 1);
+#else
 	_retries = 0;
 	ret = _writeReg(cmd, nullptr, 0);
+#endif
 
 	if (ret < 0) {
 		DF_LOG_ERR("error: request failed");
@@ -328,10 +358,32 @@ int MS5611::_collect(uint32_t &raw)
 		uint32_t w;
 	} cvt {};
 
-	uint8_t buf[3];
-
-	_retries = 0;
 	uint8_t cmd = ADDR_CMD_ADC_READ;
+
+#if defined(__DF_OCPOC)
+	uint8_t buf[4];
+	uint8_t wbuf[4];
+	wbuf[0] = cmd;
+
+	ret = _transfer(&wbuf[0], &buf[0], 4);
+
+	if (ret < 0) {
+		raw = 0;
+		return -1;
+	}
+	
+	cvt.b[0] = buf[3];
+	cvt.b[1] = buf[2];
+	cvt.b[2] = buf[1];
+	cvt.b[3] = 0;
+	raw = cvt.w;
+
+	return 0;
+
+#else
+	uint8_t buf[3];
+	_retries = 0;
+
 	ret = _readReg(cmd, &buf[0], 3);
 
 	if (ret < 0) {
@@ -346,6 +398,7 @@ int MS5611::_collect(uint32_t &raw)
 	raw = cvt.w;
 
 	return 0;
+#endif
 }
 
 void MS5611::_measure()
@@ -393,7 +446,6 @@ void MS5611::_measure()
 		}
 
 		m_measure_phase = 0;
-
 
 		m_synchronize.lock();
 

--- a/drivers/ms5611/MS5611.cpp
+++ b/drivers/ms5611/MS5611.cpp
@@ -172,9 +172,11 @@ int MS5611::loadCalibration()
 		uint8_t cmd = ADDR_PROM_SETUP + (i * 2);
 
 #if defined(__BARO_USE_SPI)
+
 		if (_bulkRead(cmd, &prom_buf[0], 2) < 0) {
 #else
 		_retries = 5;
+
 		if (_readReg(cmd, &prom_buf[0], 2) < 0) {
 #endif
 			DF_LOG_ERR("Read calibration error");
@@ -371,7 +373,7 @@ int MS5611::_collect(uint32_t &raw)
 		raw = 0;
 		return -1;
 	}
-	
+
 	cvt.b[0] = buf[3];
 	cvt.b[1] = buf[2];
 	cvt.b[2] = buf[1];

--- a/drivers/ms5611/MS5611.hpp
+++ b/drivers/ms5611/MS5611.hpp
@@ -57,7 +57,11 @@ struct ms5611_sensor_measurement {
 	int32_t pressure_mbar; // Temperature compensated pressure with 0.01 mbar resolution
 };
 
-#define BARO_DEVICE_PATH "/dev/i2c-1"
+#if defined(__DF_OCPOC)
+  #define BARO_DEVICE_PATH "/dev/spidev1.1"
+#else
+  #define BARO_DEVICE_PATH "/dev/i2c-1"
+#endif
 
 // update frequency is 50 Hz (44.4-51.3Hz ) at 8x oversampling
 #define MS5611_MEASURE_INTERVAL_US 20000 // microseconds

--- a/drivers/ms5611/MS5611.hpp
+++ b/drivers/ms5611/MS5611.hpp
@@ -58,9 +58,9 @@ struct ms5611_sensor_measurement {
 };
 
 #if defined(__DF_OCPOC)
-  #define BARO_DEVICE_PATH "/dev/spidev1.1"
+#define BARO_DEVICE_PATH "/dev/spidev1.1"
 #else
-  #define BARO_DEVICE_PATH "/dev/i2c-1"
+#define BARO_DEVICE_PATH "/dev/i2c-1"
 #endif
 
 // update frequency is 50 Hz (44.4-51.3Hz ) at 8x oversampling

--- a/framework/include/BaroSensor.hpp
+++ b/framework/include/BaroSensor.hpp
@@ -37,6 +37,10 @@
 #include "SyncObj.hpp"
 
 #if defined(__DF_OCPOC)
+#define __BARO_USE_SPI
+#endif
+
+#if defined(__BARO_USE_SPI)
 #include "SPIDevObj.hpp"
 #else
 #include "I2CDevObj.hpp"
@@ -59,7 +63,7 @@ struct baro_sensor_data {
 	uint64_t error_counter;		/*! the total number of errors detected when reading the pressure, since the system was started */
 };
 
-#if defined(__DF_OCPOC)
+#if defined(__BARO_USE_SPI)
 class BaroSensor : public SPIDevObj
 #else
 class BaroSensor : public I2CDevObj
@@ -67,7 +71,7 @@ class BaroSensor : public I2CDevObj
 {
 public:
 	BaroSensor(const char *device_path, unsigned int sample_interval_usec) :
-#if defined(__DF_OCPOC)
+#if defined(__BARO_USE_SPI)
 		SPIDevObj("BaroSensor", device_path, BARO_CLASS_PATH, sample_interval_usec)
 #else
 		I2CDevObj("BaroSensor", device_path, BARO_CLASS_PATH, sample_interval_usec)

--- a/framework/include/BaroSensor.hpp
+++ b/framework/include/BaroSensor.hpp
@@ -35,7 +35,12 @@
 
 #include <stdint.h>
 #include "SyncObj.hpp"
+
+#if defined(__DF_OCPOC)
+#include "SPIDevObj.hpp"
+#else
 #include "I2CDevObj.hpp"
+#endif
 
 #define BARO_CLASS_PATH  "/dev/baro"
 
@@ -54,11 +59,19 @@ struct baro_sensor_data {
 	uint64_t error_counter;		/*! the total number of errors detected when reading the pressure, since the system was started */
 };
 
+#if defined(__DF_OCPOC)
+class BaroSensor : public SPIDevObj
+#else
 class BaroSensor : public I2CDevObj
+#endif
 {
 public:
 	BaroSensor(const char *device_path, unsigned int sample_interval_usec) :
+#if defined(__DF_OCPOC)
+		SPIDevObj("BaroSensor", device_path, BARO_CLASS_PATH, sample_interval_usec)
+#else
 		I2CDevObj("BaroSensor", device_path, BARO_CLASS_PATH, sample_interval_usec)
+#endif
 	{}
 
 	~BaroSensor() = default;

--- a/framework/include/I2CDevObj.hpp
+++ b/framework/include/I2CDevObj.hpp
@@ -72,7 +72,7 @@ protected:
 
 	int _setSlaveConfig(uint32_t slave_address, uint32_t bus_frequency_khz, uint32_t transfer_timeout_usec);
 
-	int m_fd{-1};
+	int m_fd{ -1};
 	unsigned _retries{0};
 };
 

--- a/framework/include/ImuSensor.hpp
+++ b/framework/include/ImuSensor.hpp
@@ -51,6 +51,8 @@
 #define IMU_DEVICE_PATH "/dev/spidev0.1"
 #elif defined(__DF_EDISON)
 #define IMU_DEVICE_PATH "/dev/spidev5.1"
+#elif defined(__DF_OCPOC)
+#define IMU_DEVICE_PATH "/dev/spidev1.0"
 #else
 #define IMU_DEVICE_PATH "/dev/spidev0.0"
 #endif

--- a/framework/include/SPIDevObj.hpp
+++ b/framework/include/SPIDevObj.hpp
@@ -80,6 +80,7 @@ protected:
 	int _writeReg(uint8_t address, uint8_t *in_buffer, uint16_t length);
 	int _writeReg(uint8_t address, uint8_t val);
 	int _modifyReg(uint8_t address, uint8_t clearbits, uint8_t setbits);
+	int _transfer(uint8_t *write_buffer, uint8_t *read_buffer, uint8_t len);
 
 	int _bulkRead(uint8_t address, uint8_t *out_buffer, int length);
 	int _setBusFrequency(SPI_FREQUENCY freq_hz);

--- a/framework/src/SPIDevObj.cpp
+++ b/framework/src/SPIDevObj.cpp
@@ -41,7 +41,7 @@
 #include "OSConfig.h"
 #include "DevIOCTL.h"
 
-#if defined(__DF_RPI) || defined(__DF_EDISON) || defined(__DF_BEBOP)
+#if defined(__DF_RPI) || defined(__DF_EDISON) || defined(__DF_BEBOP) || defined(__DF_OCPOC)
 #include <sys/ioctl.h>
 #include <linux/types.h>
 #include <alloca.h>
@@ -99,7 +99,7 @@ int SPIDevObj::readReg(DevHandle &h, uint8_t address, uint8_t &val)
 
 int SPIDevObj::_readReg(uint8_t address, uint8_t &val)
 {
-#if defined(__DF_RPI) || defined(__DF_EDISON) || defined(__DF_BEBOP)
+#if defined(__DF_RPI) || defined(__DF_EDISON) || defined(__DF_BEBOP) || defined(__DF_OCPOC)
 	/* implement sensor interface via rpi2 spi */
 	// constexpr int transfer_bytes = 1 + 1; // first byte is address
 	uint8_t write_buffer[2] = {0}; // automatic write buffer
@@ -211,7 +211,7 @@ int SPIDevObj::_writeReg(uint8_t address, uint8_t val)
 
 int SPIDevObj::_writeReg(uint8_t address, uint8_t *in_buffer, uint16_t length)
 {
-#if defined(__DF_RPI) || defined(__DF_EDISON) || defined(__DF_BEBOP)
+#if defined(__DF_RPI) || defined(__DF_EDISON) || defined(__DF_BEBOP) || defined(__DF_OCPOC)
 	/* implement sensor interface via rpi2 spi */
 	uint8_t write_buffer[length + 1];// automatic write buffer: first byte is address
 	memset(&write_buffer, 0, length + 1);
@@ -282,7 +282,7 @@ int SPIDevObj::_modifyReg(uint8_t address, uint8_t clearbits, uint8_t setbits)
 
 int SPIDevObj::bulkRead(DevHandle &h, uint8_t address, uint8_t *out_buffer, int length)
 {
-#if defined(__DF_RPI) || defined(__DF_EDISON) || defined(__DF_BEBOP)
+#if defined(__DF_RPI) || defined(__DF_EDISON) || defined(__DF_BEBOP) || defined(__DF_OCPOC)
 	/* implement sensor interface via rpi2 spi */
 	SPIDevObj *obj = DevMgr::getDevObjByHandle<SPIDevObj>(h);
 
@@ -322,7 +322,7 @@ int SPIDevObj::bulkRead(DevHandle &h, uint8_t address, uint8_t *out_buffer, int 
 
 int SPIDevObj::_bulkRead(uint8_t address, uint8_t *out_buffer, int length)
 {
-#if defined(__DF_RPI) || defined(__DF_EDISON) || defined(__DF_BEBOP)
+#if defined(__DF_RPI) || defined(__DF_EDISON) || defined(__DF_BEBOP) || defined(__DF_OCPOC)
 	DF_LOG_DEBUG("_bulkRead: length = %d", length);
 	/* implement sensor interface via rpi spi */
 	int transfer_bytes = 1 + length; // first byte is address
@@ -398,7 +398,7 @@ int SPIDevObj::_bulkRead(uint8_t address, uint8_t *out_buffer, int length)
 
 int SPIDevObj::setLoopbackMode(DevHandle &h, bool enable)
 {
-#if defined(__DF_RPI) || defined(__DF_EDISON) || defined(__DF_BEBOP)
+#if defined(__DF_RPI) || defined(__DF_EDISON) || defined(__DF_BEBOP) || defined(__DF_OCPOC)
 	/* implement sensor interface via rpi2 spi */
 	DF_LOG_ERR("ERROR: attempt to set loopback mode in software fails.");
 	return -1;
@@ -415,7 +415,7 @@ int SPIDevObj::setLoopbackMode(DevHandle &h, bool enable)
 
 int SPIDevObj::setBusFrequency(DevHandle &h, SPI_FREQUENCY freq_hz)
 {
-#if defined(__DF_RPI) || defined(__DF_EDISON) || defined(__DF_BEBOP)
+#if defined(__DF_RPI) || defined(__DF_EDISON) || defined(__DF_BEBOP) || defined(__DF_OCPOC)
 	/* implement sensor interface via rpi2 spi */
 	SPIDevObj *obj = DevMgr::getDevObjByHandle<SPIDevObj>(h);
 
@@ -436,7 +436,7 @@ int SPIDevObj::setBusFrequency(DevHandle &h, SPI_FREQUENCY freq_hz)
 
 int SPIDevObj::_setBusFrequency(SPI_FREQUENCY freq_hz)
 {
-#if defined(__DF_RPI) || defined(__DF_BEBOP)
+#if defined(__DF_RPI) || defined(__DF_BEBOP) || defined(__DF_OCPOC)
 
 	/* implement sensor interface via rpi spi */
 	// RPI rounds down freq_hz to powers of 2


### PR DESCRIPTION
This PR introduces necessary changes to support the Aerotenna OcPoC flight controller.

Aside from device path changes, we ran into issues with the MS5611 baro when we first switched to using it in SPI mode - the baro would return nothing for temperature and pressure. The issue is fixed with the addition of a new SPIDevObj function which is currently only applied for OcPoC (see commits 427e654 and 2d5ea38).