### PR TITLE
Fix absolute time for new OS X versions

### DIFF
--- a/cmake/df_common.cmake
+++ b/cmake/df_common.cmake
@@ -47,12 +47,14 @@ if ("${DF_TARGET}" STREQUAL "")
 			EXEC_PROGRAM(uname ARGS -v  OUTPUT_VARIABLE DARWIN_VERSION)
 			STRING(REGEX MATCH "[0-9]+" DARWIN_VERSION ${DARWIN_VERSION})
 			# message(STATUS "DF Darwin Version: ${DARWIN_VERSION}")
-			if (DARWIN_VERSION LESS 16)
+
+			# So far no real support for monotonic timers as of macOS 10.12.1
+			# if (DARWIN_VERSION LESS 16)
 				add_definitions(
 					-DCLOCK_MONOTONIC=1
 					-D__DF_APPLE_LEGACY
 					)
-			endif()
+			# endif()
 		else()
 			set(DF_TARGET linux)
 		endif()

--- a/framework/src/Time.cpp
+++ b/framework/src/Time.cpp
@@ -65,8 +65,8 @@ using namespace DriverFramework;
 
 int DriverFramework::absoluteTime(struct timespec &ts)
 {
-#if defined(__DF_NUTTX)
-	// CLOCK_MONOTONIC not available on NuttX
+#if defined(__DF_NUTTX) || defined(__DF_APPLE_LEGACY)
+	// CLOCK_MONOTONIC not available on NuttX or OSX
 	return clock_gettime(0, &ts);
 #else
 	return clock_gettime(CLOCK_MONOTONIC, &ts);


### PR DESCRIPTION
Although it compiles without this on new macOS versions, from my experiments, there is no CLOCK_MONOTONIC as of 10.12.1.

This also causes the issue below because pthread_cond_timedwait returns immediately causing the work queue to infinite loop:
- Fixes https://github.com/PX4/Firmware/issues/6792
