### PR TITLE
MS5611: fix invalid sample reading

### DIFF
--- a/drivers/ms5611/MS5611.hpp
+++ b/drivers/ms5611/MS5611.hpp
@@ -135,6 +135,7 @@ protected:
 
 	uint32_t m_temperature_from_sensor;
 	uint32_t m_pressure_from_sensor;
+	bool m_sample_valid;
 
 	int m_measure_phase;
 };


### PR DESCRIPTION
It seems that if the temperature raw value is 0, the pressure value will also be broken, even more, if the pressure value read is zero, the next temperature reading will be broken (non-zero), hence we will have to skip the next sample too.