### PR TITLE
travis: try to compile with gcc and clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,17 @@
 
 language: cpp
 
-compiler: clang
-
 matrix:
   fast_finish: true
   include:
     - os: linux
       dist: trusty
       sudo: false
+      compiler: gcc
+    - os: linux
+      dist: trusty
+      sudo: false
+      compiler: clang
     - os: osx
       osx_image: xcode8
       sudo: true


### PR DESCRIPTION
This should fix the build in precise (12.04) which fails because of deb
backports.