### PR TITLE
WIP: mpu9250 rework

### DIFF
--- a/drivers/mpu9250/MPU9250.cpp
+++ b/drivers/mpu9250/MPU9250.cpp
@@ -33,6 +33,9 @@
 
 #include <stdint.h>
 #include <string.h>
+#include <signal.h>
+#include <byteswap.h>
+
 #include "math.h"
 #include "DriverFramework.hpp"
 #include "MPU9250.hpp"
@@ -40,42 +43,84 @@
 
 #define MPU9250_ONE_G	9.80665f
 
+#define MPU9250_CHECK_DUPLICATES (0)
+
 #define MIN(_x, _y) (_x) > (_y) ? (_y) : (_x)
 
-// Uncomment to allow additional debug output to be generated.
-// #define MPU9250_DEBUG 1
+#define MPU9250_DEBUG_TIMING 1
 
 using namespace DriverFramework;
 
+MPU9250::MPU9250(const char *device_path, bool mag_enabled) :
+	ImuSensor(device_path, 0, mag_enabled), // true = mag is enabled
+	_last_temp_c(0.0f),
+	_temp_initialized(false),
+	_mag_enabled(mag_enabled),
+	_mag(nullptr)
+	, _started(false)
+{
+	m_id.dev_id_s.devtype = DRV_DF_DEVTYPE_MPU9250;
+	// TODO: does the WHOAMI make sense as an address?
+	m_id.dev_id_s.address = MPU_WHOAMI_9250;
+
+	_counters.fifo_avg_packets = MPU9250_PACKETS_PER_CYCLE;
+}
+
+int MPU9250::writeReg_checked(uint8_t addr, uint8_t val)
+{
+	uint8_t val_out;
+	int result;
+
+	result = _writeReg(addr, val);
+
+	if (result != 0) {
+		DF_LOG_ERR("%d: write failed", (int)addr);
+		return -1;
+	}
+
+	result = _readReg(addr, val_out);
+
+	if (result != 0) {
+		DF_LOG_ERR("%d: read failed", (int)addr);
+		return -1;
+	}
+
+	if (val != val_out) {
+		DF_LOG_ERR("%d: set failed", (int)addr);
+		return -1;
+	}
+
+	return 0;
+}
+
 int MPU9250::mpu9250_init()
 {
+	int result;
 	// Use 1 MHz for normal registers.
-	_setBusFrequency(SPI_FREQUENCY_1MHZ);
+	result = _setBusFrequency(SPI_FREQUENCY_1MHZ);
+	if (result) {
+		DF_LOG_ERR("_setBusFrequency failed: %d\n", result);
+	}
 
-	/* Zero the struct */
+	_counters.accel_range_hits = 0;
+	_counters.gyro_range_hits = 0;
 
-	m_sensor_data.accel_m_s2_x = 0.0f;
-	m_sensor_data.accel_m_s2_y = 0.0f;
-	m_sensor_data.accel_m_s2_z = 0.0f;
-	m_sensor_data.gyro_rad_s_x = 0.0f;
-	m_sensor_data.gyro_rad_s_y = 0.0f;
-	m_sensor_data.gyro_rad_s_z = 0.0f;
-	m_sensor_data.mag_ga_x = 0.0f;
-	m_sensor_data.mag_ga_y = 0.0f;
-	m_sensor_data.mag_ga_z = 0.0f;
-	m_sensor_data.temp_c = 0.0f;
+#if MPU9250_CHECK_DUPLICATES
+	_counters.accel_duplicates = 0;
+	_counters.gyro_duplicates = 0;
+	_counters.mag_duplicates = 0;
+#endif
 
-	m_sensor_data.read_counter = 0;
-	m_sensor_data.error_counter = 0;
-	m_sensor_data.fifo_overflow_counter = 0;
-	m_sensor_data.fifo_corruption_counter = 0;
-	m_sensor_data.gyro_range_hit_counter = 0;
-	m_sensor_data.accel_range_hit_counter = 0;
+	_counters.mag_overflows = 0;
+	_counters.mag_overruns = 0;
 
-	m_sensor_data.fifo_sample_interval_us = 0;
-	m_sensor_data.is_last_fifo_sample = false;
+	_counters.fifo_overflows = 0;
+	_counters.fifo_reads = 0;
+	_counters.fifo_corruptions = 0;
 
-	int result = _writeReg(MPUREG_PWR_MGMT_1, BIT_H_RESET);
+	_counters.errors = 0;
+
+	result = _writeReg(MPUREG_PWR_MGMT_1, BIT_H_RESET);
 
 	if (result != 0) {
 		DF_LOG_ERR("reset failed");
@@ -84,7 +129,7 @@ int MPU9250::mpu9250_init()
 	usleep(100000);
 
 	DF_LOG_INFO("Reset MPU9250");
-	result = _writeReg(MPUREG_PWR_MGMT_1, 0);
+	result = writeReg_checked(MPUREG_PWR_MGMT_1, 0);
 
 	if (result != 0) {
 		DF_LOG_ERR("wakeup sensor failed");
@@ -92,7 +137,7 @@ int MPU9250::mpu9250_init()
 
 	usleep(1000);
 
-	result = _writeReg(MPUREG_PWR_MGMT_2, 0);
+	result = writeReg_checked(MPUREG_PWR_MGMT_2, 0);
 
 	if (result != 0) {
 		DF_LOG_ERR("enable failed");
@@ -101,7 +146,7 @@ int MPU9250::mpu9250_init()
 	usleep(1000);
 
 	// Reset I2C master and device.
-	result = _writeReg(MPUREG_USER_CTRL,
+	result = writeReg(MPUREG_USER_CTRL,
 			   BITS_USER_CTRL_I2C_MST_RST |
 			   BITS_USER_CTRL_I2C_IF_DIS);
 
@@ -112,7 +157,7 @@ int MPU9250::mpu9250_init()
 	usleep(1000);
 
 	// Reset and enable FIFO.
-	result = _writeReg(MPUREG_USER_CTRL,
+	result = writeReg(MPUREG_USER_CTRL,
 			   BITS_USER_CTRL_FIFO_RST |
 			   BITS_USER_CTRL_FIFO_EN);
 
@@ -143,61 +188,42 @@ int MPU9250::mpu9250_init()
 
 	usleep(1000);
 
-	/*
-	 * A samplerate_divider of 0 should give 1000Hz:
-	 *
-	 * sample_rate = internal_sample_rate / (1+samplerate_divider)
-	 *
-	 * This is only used when FCHOICE is 0b11, FCHOICE_B (inverted) 0x00,
-	 * therefore commented out.
-	 */
-	//uint8_t samplerate_divider = 0;
-	//result = _writeReg(MPUREG_FIFO_EN, samplerate_divider);
-	//if (result != 0) {
-	//	DF_LOG_ERR("sample rate config failed");
-	//}
-	//usleep(1000);
-
-#if defined(__DF_EDISON)
-	//Setting the gyro bandwidth to 250 Hz corresponds to
-	//8kHz sampling frequency which is too high for the Edison.
-	//Therefore, we use the gyro bandwith of 184 Hz which corresponds to 1kHz sampling frequency.
-	result = _writeReg(MPUREG_CONFIG,
-			   BITS_DLPF_CFG_184HZ | BITS_CONFIG_FIFO_MODE_OVERWRITE);
-#elif defined(__DF_RPI_SINGLE)
-	result = _writeReg(MPUREG_CONFIG,
-			   BITS_DLPF_CFG_184HZ | BITS_CONFIG_FIFO_MODE_OVERWRITE);
-#else
-	result = _writeReg(MPUREG_CONFIG,
-			   BITS_DLPF_CFG_41HZ | BITS_CONFIG_FIFO_MODE_OVERWRITE);
-#endif
+	uint8_t regValue;
+	regValue = BITS_DLPF_CFG_184HZ | BITS_CONFIG_FIFO_MODE_OVERWRITE;
+	result = writeReg_checked(MPUREG_CONFIG, regValue);
 
 	if (result != 0) {
-		DF_LOG_ERR("config failed");
+		DF_LOG_ERR("MPUREG_CONFIG: write failed");
+		return -1;
 	}
 
 	usleep(1000);
 
-	result = _writeReg(MPUREG_GYRO_CONFIG, BITS_FS_2000DPS | BITS_BW_LT3600HZ);
+	regValue = BITS_FS_2000DPS | BITS_BW_LT3600HZ;
+	result = writeReg_checked(MPUREG_GYRO_CONFIG, regValue);
 
 	if (result != 0) {
-		DF_LOG_ERR("Gyro scale config failed");
+		DF_LOG_ERR("MPUREG_GYRO_CONFIG: write failed");
+		return -1;
 	}
 
 	usleep(1000);
 
-	result = _writeReg(MPUREG_ACCEL_CONFIG, BITS_ACCEL_CONFIG_16G);
+	/* Accel config */
+	regValue = BITS_ACCEL_CONFIG_16G;
+	result = writeReg_checked(MPUREG_ACCEL_CONFIG, regValue);
 
 	if (result != 0) {
-		DF_LOG_ERR("Accel scale config failed");
+		DF_LOG_ERR("MPUREG_ACCEL_CONFIG: write failed");
 	}
 
 	usleep(1000);
 
-	result = _writeReg(MPUREG_ACCEL_CONFIG2, BITS_ACCEL_CONFIG2_BW_41HZ);
+	regValue = BITS_ACCEL_CONFIG2_BW_218HZ;
+	result = writeReg_checked(MPUREG_ACCEL_CONFIG2, regValue);
 
 	if (result != 0) {
-		DF_LOG_ERR("Accel scale config2 failed");
+		DF_LOG_ERR("MPUREG_ACCEL_CONFIG2: write failed");
 	}
 
 	usleep(1000);
@@ -226,6 +252,15 @@ int MPU9250::mpu9250_init()
 	// Clear Interrupt Status
 	clear_int_status();
 
+	if (_mag_enabled) {
+		_size_of_fifo_packet = sizeof(fifo_packet_with_mag);
+
+	} else {
+		_size_of_fifo_packet = sizeof(fifo_packet);
+	}
+
+	_max_buf_len = (MPU_MAX_LEN_FIFO_IN_BYTES / _size_of_fifo_packet) * _size_of_fifo_packet;
+
 	return 0;
 }
 
@@ -247,11 +282,37 @@ int MPU9250::mpu9250_deinit()
 	return 0;
 }
 
+int MPU9250::pinThread(int cpu)
+{
+	int ret;
+	cpu_set_t cpuset;
+	/* Set this cpu-affinity */
+	CPU_ZERO(&cpuset);
+	CPU_SET(cpu, &cpuset);
+	ret = pthread_setaffinity_np(m_thread_id, sizeof(cpu_set_t), &cpuset);
+	if (ret != 0) {
+		DF_LOG_ERR("pthread_setaffinity_np(%d) failed, ret=%d\n", cpu, ret);
+	}
+
+	return ret;
+}
+
 int MPU9250::start()
 {
+	pthread_attr_t attr;
+	struct sched_param param = {};
+	int result;
+
+	if (_started) {
+		DF_LOG_ERR("already started mpu9250!!\n");
+		return 0;
+	}
+
+	_started = true;
+
 	/* Open the device path specified in the class initialization. */
 	// attempt to open device in start()
-	int result = SPIDevObj::start();
+	result = SPIDevObj::start();
 
 	if (result != 0) {
 		DF_LOG_ERR("DevObj start failed");
@@ -292,9 +353,51 @@ int MPU9250::start()
 	result = DevObj::start();
 
 	if (result != 0) {
-		DF_LOG_ERR("DevObj start failed");
-		return result;
+		/* This will report failure since the sampling time is NULL */
 	}
+
+	result = pthread_attr_init(&attr);
+
+	if (result != 0) {
+		DF_LOG_ERR("pthread_attr_init: %d", result);
+		goto exit;
+	}
+
+	result = pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
+
+	if (result != 0) {
+		DF_LOG_ERR("pthread_attr_setinheritsched: %d", result);
+		goto exit;
+	}
+
+	result = pthread_attr_setschedpolicy(&attr, SCHED_FIFO);
+
+	if (result != 0) {
+		DF_LOG_ERR("pthread_attr_setschedpolicy: %d", result);
+		goto exit;
+	}
+
+	param.sched_priority = sched_get_priority_max(SCHED_FIFO) - 1;
+	result = pthread_attr_setschedparam(&attr, &param);
+
+	if (result != 0) {
+		DF_LOG_ERR("pthread_attr_setschedparam: %d", result);
+		goto exit;
+	}
+
+	result = pthread_create(&m_thread_id, &attr, MPU9250::threadFunc, this);
+
+	if (result != 0) {
+		if (result == EPERM) {
+			DF_LOG_ERR("pthread_create: %d; run as root!", result);
+			goto exit;
+		} else {
+			DF_LOG_ERR("pthread_create: %d", result);
+			goto exit;
+		}
+	}
+
+	pthread_attr_destroy(&attr);
 
 exit:
 	return result;
@@ -302,6 +405,7 @@ exit:
 
 int MPU9250::stop()
 {
+	void *retval;
 	int result = mpu9250_deinit();
 
 	if (result != 0) {
@@ -317,28 +421,44 @@ int MPU9250::stop()
 		return result;
 	}
 
-	// We need to wait so that all measure calls are finished before
-	// closing the device.
-	usleep(10000);
+	result = pthread_kill(m_thread_id, SIGUSR1);
+	if (result != 0) {
+		DF_LOG_ERR("pthread_kill: %d", result);
+		return result;
+	}
+
+	result = pthread_join(m_thread_id, &retval);
+	if (result != 0) {
+		DF_LOG_ERR("pthread_join: %d", result);
+	}
 
 	return 0;
 }
 
 int MPU9250::get_fifo_count()
 {
-	int16_t num_bytes = 0x0;
+	int ret;
 
-	// Use 1 MHz for normal registers.
-	_setBusFrequency(SPI_FREQUENCY_1MHZ);
-	int ret = _bulkRead(MPUREG_FIFO_COUNTH, (uint8_t *) &num_bytes,
-			    sizeof(num_bytes));
+	uint8_t write_buf[3];
+	uint8_t read_buf[3];
+	int16_t *num_bytes = (int16_t*)&read_buf[1];
 
-	if (ret == 0) {
+	struct spi_ioc_transfer spi_transfer;
 
-		/* TODO: add ifdef for endianness */
-		num_bytes = swap16(num_bytes);
+	write_buf[0] = MPUREG_FIFO_COUNTH | 0x80;
 
-		return num_bytes;
+	memset(&spi_transfer, 0, sizeof(spi_ioc_transfer));
+
+	spi_transfer.rx_buf = (unsigned long)read_buf;
+	spi_transfer.len = 3;
+	spi_transfer.tx_buf = (unsigned long)write_buf;
+	spi_transfer.bits_per_word = 8;
+	spi_transfer.delay_usecs = 0;
+
+	ret = ::ioctl(m_fd, SPI_IOC_MESSAGE(1), &spi_transfer);
+
+	if (ret == 3) {
+		return bswap_16(*num_bytes);
 
 	} else {
 		DF_LOG_ERR("FIFO count read failed");
@@ -348,10 +468,20 @@ int MPU9250::get_fifo_count()
 
 void MPU9250::reset_fifo()
 {
-	// Use 1 MHz for normal registers.
-	_setBusFrequency(SPI_FREQUENCY_1MHZ);
-
 	int result;
+
+	/*
+	 * FIFO Reset is async and may be reset during an incomplete fill.
+	 * To avoid this we:
+	 * 1. Disable FIFO
+	 * 2. Reset FIFO
+	 * 3. Enable FIFO
+	 */
+
+	result = _writeReg(MPUREG_FIFO_EN, 0);
+	if (result != 0) {
+		DF_LOG_ERR("MPUREG_FIFO_EN: disable failed");
+	}
 
 	result = _modifyReg(MPUREG_USER_CTRL,
 			    0,
@@ -359,7 +489,25 @@ void MPU9250::reset_fifo()
 			    BITS_USER_CTRL_FIFO_EN);
 
 	if (result != 0) {
-		DF_LOG_ERR("FIFO reset failed");
+		DF_LOG_ERR("MPUREG_USER_CTRL: fifo rst failed");
+	}
+
+	if (_mag_enabled) {
+		result = _writeReg(MPUREG_FIFO_EN,
+				   BITS_FIFO_ENABLE_TEMP_OUT | BITS_FIFO_ENABLE_GYRO_XOUT
+				   | BITS_FIFO_ENABLE_GYRO_YOUT
+				   | BITS_FIFO_ENABLE_GYRO_ZOUT | BITS_FIFO_ENABLE_ACCEL
+				   | BITS_FIFO_ENABLE_SLV0); // SLV0 is configured for bulk transfer of mag data over I2C
+
+	} else {
+		result = _writeReg(MPUREG_FIFO_EN,
+				   BITS_FIFO_ENABLE_TEMP_OUT | BITS_FIFO_ENABLE_GYRO_XOUT
+				   | BITS_FIFO_ENABLE_GYRO_YOUT
+				   | BITS_FIFO_ENABLE_GYRO_ZOUT | BITS_FIFO_ENABLE_ACCEL);
+	}
+
+	if (result != 0) {
+		DF_LOG_ERR("MPUREG_FIFO_EN: enable failed");
 	}
 }
 
@@ -374,122 +522,124 @@ void MPU9250::clear_int_status()
 		DF_LOG_ERR("Interrupt status clear failed");
 	}
 }
-
 void MPU9250::_measure()
 {
-	// Use 1 MHz for normal registers.
-	_setBusFrequency(SPI_FREQUENCY_1MHZ);
-	uint8_t int_status = 0;
-	int result = _readReg(MPUREG_INT_STATUS, int_status);
+}
+
+int MPU9250::read_fifo(int num_bytes)
+{
+	int ret;
+
+	uint8_t write_buf[45];
+
+	struct spi_ioc_transfer spi_transfer;
+
+	write_buf[0] = MPUREG_FIFO_R_W | 0x80;
+
+	memset(&spi_transfer, 0, sizeof(spi_ioc_transfer));
+
+	spi_transfer.rx_buf = (unsigned long)fifo_read_buf;
+	spi_transfer.len = num_bytes + 1;
+	spi_transfer.tx_buf = (unsigned long)write_buf;
+	spi_transfer.bits_per_word = 8;
+	spi_transfer.delay_usecs = 0;
+
+	ret = ::ioctl(m_fd, SPI_IOC_MESSAGE(1), &spi_transfer);
+	if (ret != num_bytes + 1) {
+		DF_LOG_ERR("ret: %d != %d", ret, num_bytes + 1);
+	}
+
+	return 0;
+}
+
+int MPU9250::measure()
+{
+	int sleepTimes = 0;
+	int result;
+	int bytes_to_read;
+	int read_len;
+	int packets;
+	uint8_t int_status;
+
+	result = _setBusFrequency(SPI_FREQUENCY_1MHZ);
+	if (result != 0) {
+		DF_LOG_ERR("_setBusFrequency failed: %d\n", result);
+	}
+
+	// Get FIFO byte count to read and floor it to the report size.
+	do {
+		bytes_to_read = get_fifo_count();
+		if (bytes_to_read >= _size_of_fifo_packet) {
+			break;
+		} else if (bytes_to_read < 0) {
+			_counters.errors++;
+			DF_LOG_ERR("bytes_to_read: %d\n", bytes_to_read);
+			goto out;
+		} else if (bytes_to_read < _size_of_fifo_packet) {
+			/* TODO: replace usleep with nanosleep, check for interrupts, limit the sleep time */
+			sleepTimes++;
+			usleep(1);
+		}
+	} while (true);
+
+	result = _readReg(MPUREG_INT_STATUS, int_status);
 
 	if (result != 0) {
-		++m_sensor_data.error_counter;
-		return;
+		_counters.errors++;
+		DF_LOG_ERR("MPUREG_INT_STATUS fail: %d\n", result);
+		goto out;
 	}
 
 	if (int_status & BITS_INT_STATUS_FIFO_OVERFLOW) {
 		reset_fifo();
 
-		++m_sensor_data.fifo_overflow_counter;
+		_counters.fifo_overflows++;
 		DF_LOG_ERR("FIFO overflow");
 
-		return;
+		goto out;
 	}
 
-	int size_of_fifo_packet;
+	bytes_to_read = (bytes_to_read / _size_of_fifo_packet) * _size_of_fifo_packet;
 
-	if (_mag_enabled) {
-		size_of_fifo_packet = sizeof(fifo_packet_with_mag);
+	_counters.fifo_avg_packets = (0.95f * _counters.fifo_avg_packets) + (0.05f * (bytes_to_read / _size_of_fifo_packet));
 
-	} else {
-		size_of_fifo_packet = sizeof(fifo_packet);
-	}
+	read_len = MIN(bytes_to_read, _max_buf_len);
 
-	// Get FIFO byte count to read and floor it to the report size.
-	int bytes_to_read = get_fifo_count() / size_of_fifo_packet
-			    * size_of_fifo_packet;
-
-	// It looks like the FIFO doesn't actually deliver at 8kHz like it is supposed to.
-	// Therefore, we need to adapt the interval which we pass on to the integrator.
-	// The filtering is to lower the jitter that could result through the calculation
-	// because of the fact that the bytes we fetch per _measure() cycle varies.
-	_packets_per_cycle_filtered = (0.95f * _packets_per_cycle_filtered) + (0.05f * (bytes_to_read / size_of_fifo_packet));
-
-	if (bytes_to_read < 0) {
-		++m_sensor_data.error_counter;
-		return;
-	}
-
-	// Allocate a buffer large enough for n complete packets, read from the
-	// sensor FIFO.
-	const unsigned buf_len = (MPU_MAX_LEN_FIFO_IN_BYTES / size_of_fifo_packet) * size_of_fifo_packet;
-	uint8_t fifo_read_buf[buf_len];
-
-	if (bytes_to_read <= 0) {
-		++m_sensor_data.error_counter;
-		return;
-	}
-
-	const unsigned read_len = MIN((unsigned)bytes_to_read, buf_len);
-	memset(fifo_read_buf, 0x0, buf_len);
-
-	// According to the protocol specs, all sensor and interrupt registers may be read at 20 MHz.
-	// It is unclear what rate the FIFO register can be read at.
-	// If the FIFO buffer was read at 20 MHz, two effects were seen:
-	// - The buffer is off-by-one. So the report "starts" at &fifo_read_buf[i+1].
-	// - Also, the FIFO buffer seemed to prone to random corruption (or shifting), unless
-	//   all other sensors ran very smooth. (E.g. Changing the bus speed of the HMC5883 driver from
-	//   400 kHz to 100 kHz could cause corruption because this driver wouldn't run as regularly.
-	//
-	// Luckily 10 MHz seems to work fine.
-
-#if defined(__DF_EDISON)
-	//FIFO corrupt at 10MHz.
-	_setBusFrequency(SPI_FREQUENCY_5MHZ);
-#elif defined(__DF_RPI_SINGLE)
-	_setBusFrequency(SPI_FREQUENCY_5MHZ);
-#else
-	_setBusFrequency(SPI_FREQUENCY_10MHZ);
-#endif
-
-	result = _bulkRead(MPUREG_FIFO_R_W, fifo_read_buf, read_len);
+	result = _setBusFrequency(MPU9250_SPI_FIFO_FREQ);
 
 	if (result != 0) {
-		++m_sensor_data.error_counter;
-		return;
+		DF_LOG_ERR("_setBusFrequency failed: %d\n", result);
 	}
 
-	for (unsigned packet_index = 0; packet_index < read_len / size_of_fifo_packet; ++packet_index) {
+	result = read_fifo(read_len);
 
-		fifo_packet *report = (fifo_packet *)(&fifo_read_buf[packet_index	* size_of_fifo_packet]);
+	if (result != 0) {
+		_counters.errors++;
+		return 0;
+	}
 
-		/* TODO: add ifdef for endianness */
-		report->accel_x = swap16(report->accel_x);
-		report->accel_y = swap16(report->accel_y);
-		report->accel_z = swap16(report->accel_z);
-		report->temp = swap16(report->temp);
-		report->gyro_x = swap16(report->gyro_x);
-		report->gyro_y = swap16(report->gyro_y);
-		report->gyro_z = swap16(report->gyro_z);
+	packets = read_len / _size_of_fifo_packet;
+#ifdef MPU9250_DEBUG_TIMING
+	if (packets != 1) {
+		DF_LOG_INFO("packets: %d", packets);
+	}
+#endif
 
+	for (unsigned packet_index = 0; packet_index < packets; ++packet_index) {
 
-		// Check if the full accel range of the accel has been used. If this occurs, it is
-		// either a spike due to a crash/landing or a sign that the vibrations levels
-		// measured are excessive.
-		if (report->accel_x == INT16_MIN || report->accel_x == INT16_MAX ||
-		    report->accel_y == INT16_MIN || report->accel_y == INT16_MAX ||
-		    report->accel_z == INT16_MIN || report->accel_z == INT16_MAX) {
-			++m_sensor_data.accel_range_hit_counter;
-		}
+		fifo_packet_with_mag *report = (fifo_packet_with_mag *)(&fifo_read_buf[1 + packet_index * _size_of_fifo_packet]);
 
-		// Also check the full gyro range, however, this is very unlikely to happen.
-		if (report->gyro_x == INT16_MIN || report->gyro_x == INT16_MAX ||
-		    report->gyro_y == INT16_MIN || report->gyro_y == INT16_MAX ||
-		    report->gyro_z == INT16_MIN || report->gyro_z == INT16_MAX) {
-			++m_sensor_data.gyro_range_hit_counter;
-		}
+		report->temp = bswap_16(report->temp);
 
-		const float temp_c = float(report->temp) / 361.0f + 35.0f;
+		const float temp_c = (float)report->temp / 361.0f + 35.0f;
+
+		bool publish_accel = true;
+		bool publish_gyro = true;
+		bool publish_mag = false;
+
+		struct accel_data accel_data;
+		struct gyro_data gyro_data;
+		struct mag_data mag_data;
 
 		// Use the temperature field to try to detect if we (ever) fall out of sync with
 		// the FIFO buffer. If the temperature changes insane amounts, reset the FIFO logic
@@ -512,78 +662,239 @@ void MPU9250::_measure()
 				DF_LOG_ERR(
 					"FIFO corrupt, temp difference: %f, last temp: %f, current temp: %f",
 					(double)fabsf(temp_c - _last_temp_c), (double)_last_temp_c, (double)temp_c);
+				result = _setBusFrequency(SPI_FREQUENCY_1MHZ);
+				if (result != 0) {
+					DF_LOG_ERR("_setBusFrequency failed: %d\n", result);
+				}
+
 				reset_fifo();
 				_temp_initialized = false;
-				++m_sensor_data.fifo_corruption_counter;
-				return;
+				_counters.fifo_corruptions++;
+
+				goto out;
 			}
 
 			_last_temp_c = temp_c;
 		}
 
-		m_sensor_data.accel_m_s2_x = float(report->accel_x)
-					     * (MPU9250_ONE_G / 2048.0f);
-		m_sensor_data.accel_m_s2_y = float(report->accel_y)
-					     * (MPU9250_ONE_G / 2048.0f);
-		m_sensor_data.accel_m_s2_z = float(report->accel_z)
-					     * (MPU9250_ONE_G / 2048.0f);
-		m_sensor_data.temp_c = temp_c;
-		m_sensor_data.gyro_rad_s_x = float(report->gyro_x) * GYRO_RAW_TO_RAD_S;
-		m_sensor_data.gyro_rad_s_y = float(report->gyro_y) * GYRO_RAW_TO_RAD_S;
-		m_sensor_data.gyro_rad_s_z = float(report->gyro_z) * GYRO_RAW_TO_RAD_S;
+#if MPU9250_CHECK_DUPLICATES
+		if (check_duplicate_accel((const uint8_t *)&report->accel_x)) {
+			_counters.accel_duplicates++;
+		}
+#endif
+
+		/* TODO: add ifdef for endianness */
+		report->accel_x = bswap_16(report->accel_x);
+		report->accel_y = bswap_16(report->accel_y);
+		report->accel_z = bswap_16(report->accel_z);
+
+		// Check if the full accel range of the accel has been used. If this occurs, it is
+		// either a spike due to a crash/landing or a sign that the vibrations levels
+		// measured are excessive.
+		if (report->accel_x == INT16_MIN || report->accel_x == INT16_MAX ||
+				report->accel_y == INT16_MIN || report->accel_y == INT16_MAX ||
+				report->accel_z == INT16_MIN || report->accel_z == INT16_MAX) {
+			_counters.accel_range_hits++;
+		}
+
+		accel_data.accel_m_s2_x = float(report->accel_x)
+								  * (MPU9250_ONE_G / 2048.0f);
+		accel_data.accel_m_s2_y = float(report->accel_y)
+								  * (MPU9250_ONE_G / 2048.0f);
+		accel_data.accel_m_s2_z = float(report->accel_z)
+								  * (MPU9250_ONE_G / 2048.0f);
+
+#if MPU9250_CHECK_DUPLICATES
+		if (check_duplicate_gyro((const uint8_t *)&report->gyro_x)) {
+			_counters.gyro_duplicates++;
+		}
+#endif
+
+		/* TODO: add ifdef for endianness */
+		report->gyro_x = bswap_16(report->gyro_x);
+		report->gyro_y = bswap_16(report->gyro_y);
+		report->gyro_z = bswap_16(report->gyro_z);
+
+		// Also check the full gyro range, however, this is very unlikely to happen.
+		if (report->gyro_x == INT16_MIN || report->gyro_x == INT16_MAX ||
+				report->gyro_y == INT16_MIN || report->gyro_y == INT16_MAX ||
+				report->gyro_z == INT16_MIN || report->gyro_z == INT16_MAX) {
+			_counters.gyro_range_hits++;
+		}
+
+		gyro_data.gyro_rad_s_x = float(report->gyro_x) * GYRO_RAW_TO_RAD_S;
+		gyro_data.gyro_rad_s_y = float(report->gyro_y) * GYRO_RAW_TO_RAD_S;
+		gyro_data.gyro_rad_s_z = float(report->gyro_z) * GYRO_RAW_TO_RAD_S;
 
 		if (_mag_enabled) {
-			struct fifo_packet_with_mag *report_with_mag_data = (struct fifo_packet_with_mag *)report;
+			int mag_error;
 
-			int mag_error = _mag->process((const struct mag_data &)report_with_mag_data->mag_st1,
-						      m_sensor_data.mag_ga_x,
-						      m_sensor_data.mag_ga_y,
-						      m_sensor_data.mag_ga_z);
+			_mag_reads++;
+#if MPU9250_CHECK_DUPLICATES
+			if (check_duplicate_mag((const uint8_t *)&report->mag_x)) {
+				_counters.mag_duplicates++;
+			}
+#endif
+
+			mag_error = _mag->process((const struct mag_data_packet &)report->mag_st1,
+					mag_data.mag_ga_x,
+					mag_data.mag_ga_y,
+					mag_data.mag_ga_z);
 
 			if (mag_error == MAG_ERROR_DATA_OVERFLOW) {
-				m_sensor_data.mag_fifo_overflow_counter++;
+				_counters.mag_overflows++;
+
+			} else if (mag_error == MAG_ERROR_DATA_OVERRUN) {
+				_counters.mag_overruns++;
+			}
+
+			if (_mag_reads / 10 >= 1 && mag_error == 0) {
+				publish_mag = true;
+				_mag_reads = 0;
 			}
 		}
 
-		// Pass on the sampling interval between FIFO samples at 8kHz.
-		m_sensor_data.fifo_sample_interval_us = 1000000 / MPU9250_MEASURE_INTERVAL_US
-							/ _packets_per_cycle_filtered;
+		_counters.fifo_reads++;
 
-		// Flag if this is the last sample, and _publish() should wrap up the data it has received.
-		m_sensor_data.is_last_fifo_sample = ((packet_index + 1) == (read_len / size_of_fifo_packet));
-
-		++m_sensor_data.read_counter;
-
-		// Generate debug output every second, assuming that a sample is generated every
-		// 125 usecs
-#ifdef MPU9250_DEBUG
-
-		if (++m_sensor_data.read_counter % (1000000 / m_sensor_data.fifo_sample_interval_us) == 0) {
-
-			DF_LOG_INFO("IMU: accel: [%f, %f, %f]",
-				    (double)m_sensor_data.accel_m_s2_x,
-				    (double)m_sensor_data.accel_m_s2_y,
-				    (double)m_sensor_data.accel_m_s2_z);
-			DF_LOG_INFO("     gyro:  [%f, %f, %f]",
-				    (double)m_sensor_data.gyro_rad_s_x,
-				    (double)m_sensor_data.gyro_rad_s_y,
-				    (double)m_sensor_data.gyro_rad_s_z);
-			DF_LOG_INFO("    temp:  %f C", (double)m_sensor_data.temp_c);
+		if (publish_accel) {
+			_publish(accel_data);
 		}
 
-#endif
-
-#ifdef MPU9250_DEBUG
-
-		if (_mag_enabled && mag_error == 0) {
-			if ((m_sensor_data.read_counter % 10000) == 0) {
-				DF_LOG_INFO("     mag:  [%f, %f, %f] ga",
-					    m_sensor_data.mag_ga_x, m_sensor_data.mag_ga_y, m_sensor_data.mag_ga_z);
-			}
+		if (publish_gyro) {
+			_publish(gyro_data);
 		}
 
-#endif
-
-		_publish(m_sensor_data);
+		if (publish_mag) {
+			_publish(mag_data);
+		}
 	}
+
+out:
+	return sleepTimes;
+}
+
+#if MPU9250_CHECK_DUPLICATES
+bool MPU9250::check_duplicate_accel(const uint8_t *data)
+{
+	if (memcmp(data, &_last_accel_data, sizeof(_last_accel_data)) == 0) {
+		return true;
+	}
+
+	memcpy(_last_accel_data, data, sizeof(_last_accel_data));
+
+	return false;
+}
+
+bool MPU9250::check_duplicate_gyro(const uint8_t *data)
+{
+	if (memcmp(data, &_last_gyro_data, sizeof(_last_gyro_data)) == 0) {
+		return true;
+	}
+
+	memcpy(_last_gyro_data, data, sizeof(_last_gyro_data));
+
+	return false;
+}
+
+bool MPU9250::check_duplicate_mag(const uint8_t *data)
+{
+	if (memcmp(data, &_last_mag_data, sizeof(_last_mag_data)) == 0) {
+		return true;
+	}
+
+	memcpy(_last_mag_data, data, sizeof(_last_mag_data));
+
+	return false;
+}
+#endif
+
+#ifdef MPU9250_DEBUG_TIMING
+static long int timespec_diff(struct timespec *start, struct timespec *stop)
+{
+	long int diff = (stop->tv_sec - start->tv_sec) * 1000000000LL + (stop->tv_nsec - start->tv_nsec);
+	return diff;
+}
+#endif
+
+static void timespec_inc(struct timespec *timespec, long dt)
+{
+	timespec->tv_nsec += dt;
+
+	while (timespec->tv_nsec >= 1000000000) {
+		/* timespec nsec overflow */
+		timespec->tv_sec++;
+		timespec->tv_nsec -= 1000000000;
+	}
+}
+
+#include <asm/unistd.h>
+
+void* MPU9250::threadFunc(void *arg)
+{
+	MPU9250 *instance = static_cast<MPU9250*>(arg);
+
+	long wakeup_period_ns = MPU9250_MEASURE_INTERVAL_US * 1000 - (7 * 1000);
+	struct timespec next_wakeup;
+#ifdef MPU9250_DEBUG_TIMING
+	struct timespec start_time;
+	struct timespec end_time;
+	struct timespec sleep_time;
+	long int sleep_dt;
+	long int exec_dt;
+	double sleep_dt_mean = 0;
+	double exec_dt_mean = 0;
+	int stats_print_cnt = 0;
+
+	clock_gettime(CLOCK_MONOTONIC, &sleep_time);
+#endif
+
+	DF_LOG_ERR("MPU9250 TID: %d", (long int)syscall(__NR_gettid));
+
+	clock_gettime(CLOCK_MONOTONIC, &next_wakeup);
+	while (1) {
+#ifdef MPU9250_DEBUG_TIMING
+		clock_gettime(CLOCK_MONOTONIC, &start_time);
+#endif
+		int jitter = instance->measure();
+#ifdef MPU9250_DEBUG_TIMING
+		clock_gettime(CLOCK_MONOTONIC, &end_time);
+#endif
+
+#ifdef MPU9250_DEBUG_TIMING
+		sleep_dt = timespec_diff(&sleep_time, &start_time);
+		exec_dt = timespec_diff(&start_time, &end_time);
+		sleep_dt_mean = (sleep_dt_mean + sleep_dt) / 2.0;
+		exec_dt_mean = (exec_dt_mean + exec_dt) / 2.0;
+
+		if (jitter != 0) {
+			if (false)
+				printf("MPU9250 jitter: %d\n", jitter);
+		}
+
+
+		if (stats_print_cnt / 1000 != 0) {
+			printf("MPU9250 sleep_dt_mean: %f\n", sleep_dt_mean);
+			printf("MPU9250 exec_dt_mean: %f\n", exec_dt_mean);
+			stats_print_cnt = 0;
+		} else {
+			stats_print_cnt++;
+		}
+#endif
+
+		timespec_inc(&next_wakeup, wakeup_period_ns + jitter);
+
+#ifdef MPU9250_DEBUG_TIMING
+		clock_gettime(CLOCK_MONOTONIC, &sleep_time);
+#endif
+		int ret = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &next_wakeup, NULL);
+		if (ret == EINTR) {
+			DF_LOG_ERR("MPU9250 someone sent me a signal");
+			return NULL;
+		} else if (ret != 0) {
+			DF_LOG_ERR("MPU9250 fail to sleep: %d", ret);
+			return NULL;
+		}
+	}
+
+	return NULL;
 }

--- a/drivers/mpu9250/MPU9250.cpp
+++ b/drivers/mpu9250/MPU9250.cpp
@@ -235,7 +235,7 @@ int MPU9250::mpu9250_init()
 			// Initialize the magnetometer, providing the output data rate for
 			// data read from the IMU FIFO.  This is used to calculate the I2C
 			// delay for reading the magnetometer.
-			result = _mag->initialize(MPU9250_MEASURE_INTERVAL_US);
+			result = _mag->initialize(1000);
 
 			if (result != 0) {
 				DF_LOG_ERR("Magnetometer initialization failed");

--- a/drivers/mpu9250/MPU9250.cpp
+++ b/drivers/mpu9250/MPU9250.cpp
@@ -561,7 +561,7 @@ int MPU9250::measure()
 	int read_len;
 	int packets;
 	uint8_t int_status;
-	uint8_t fifo_read_buf[8 * MPU9250_MAX_PACKET_SIZE + 1];
+	uint8_t fifo_read_buf[MPU9250_SW_FIFO_SIZE];
 
 	result = _setBusFrequency(SPI_FREQUENCY_1MHZ);
 	if (result != 0) {
@@ -588,7 +588,7 @@ int MPU9250::measure()
 		reset_fifo();
 
 		_counters.fifo_overflows++;
-		DF_LOG_ERR("bytes_to_read too big");
+		DF_LOG_ERR("bytes_to_read too big: %d", bytes_to_read);
 
 		goto out;
 	}

--- a/drivers/mpu9250/MPU9250.hpp
+++ b/drivers/mpu9250/MPU9250.hpp
@@ -285,6 +285,9 @@ struct mag_data_packet {
 };
 #pragma pack(pop)
 
+#define MPU9250_MAX_PACKET_SIZE (22) /* sizeof(fifo_packet_with_mag) */
+#define MPU9250_SW_FIFO_SIZE (8 * MPU9250_MAX_PACKET_SIZE + 1)
+
 class MPU9250: public ImuSensor
 {
 public:
@@ -368,7 +371,7 @@ private:
 	int get_fifo_count();
 
 	void reset_fifo();
-	int read_fifo(int num_bytes);
+	int read_fifo(uint8_t *dst, int num_bytes);
 
 	void clear_int_status();
 
@@ -384,7 +387,6 @@ private:
 
 	int _size_of_fifo_packet;
 	int _max_buf_len;
-	uint8_t fifo_read_buf[MPU_MAX_LEN_FIFO_IN_BYTES + 1];
 
 	pthread_t m_thread_id = { 0 };
 

--- a/drivers/mpu9250/MPU9250_mag.cpp
+++ b/drivers/mpu9250/MPU9250_mag.cpp
@@ -473,7 +473,7 @@ int MPU9250_mag::write_reg(uint8_t reg, uint8_t val)
 }
 
 
-int MPU9250_mag::process(const struct mag_data &data, float &mag_ga_x, float &mag_ga_y, float &mag_ga_z)
+int MPU9250_mag::process(const struct mag_data_packet &data, float &mag_ga_x, float &mag_ga_y, float &mag_ga_z)
 {
 #ifdef MPU9250_MAG_DEBUG
 	static int hofl_bit_counter = 0;
@@ -489,7 +489,13 @@ int MPU9250_mag::process(const struct mag_data &data, float &mag_ga_x, float &ma
 		}
 
 #endif
+//		DF_LOG_ERR("MAG_ERROR_DATA_OVERFLOW");
 		return MAG_ERROR_DATA_OVERFLOW;
+	}
+
+	if (data.mag_st1 & BIT_MAG_OVERRUN) {
+//		DF_LOG_ERR("MAG_ERROR_DATA_OVERRUN");
+		return MAG_ERROR_DATA_OVERRUN;
 	}
 
 #ifdef MPU9250_MAG_DEBUG
@@ -500,7 +506,6 @@ int MPU9250_mag::process(const struct mag_data &data, float &mag_ga_x, float &ma
 	mag_ga_x = data.mag_x * _mag_sens_adj[0] * MAG_RAW_TO_GAUSS;
 	mag_ga_y = data.mag_y * _mag_sens_adj[1] * MAG_RAW_TO_GAUSS;
 	mag_ga_z = data.mag_z * _mag_sens_adj[2] * MAG_RAW_TO_GAUSS;
-
 
 	// Swap magnetometer x and y axis, and invert z because internal mag in MPU9250
 	// has a different orientation.

--- a/drivers/mpu9250/MPU9250_mag.hpp
+++ b/drivers/mpu9250/MPU9250_mag.hpp
@@ -70,10 +70,12 @@ class MPU9250;
 #define BIT_MAG_CNTL1_FUSE_ROM_ACCESS_MODE		0xF
 #define BIT_MAG_CNTL1_16_BITS 				0x10
 #define BIT_MAG_HOFL					0x08
+#define BIT_MAG_OVERRUN					0x02
 
 #define BIT_MAG_CNTL2_SOFT_RESET			0x01
 
 #define MAG_ERROR_DATA_OVERFLOW				-3
+#define MAG_ERROR_DATA_OVERRUN				-4
 
 // 16bit mode: 0.15uTesla/LSB, 100 uTesla == 1 Gauss
 #define MAG_RAW_TO_GAUSS 	 (0.15f / 100.0f)
@@ -148,7 +150,7 @@ public:
 	// @return
 	// - 0 on success
 	// - -errno on failure
-	int process(const struct mag_data &data, float &mag_ga_x, float &mag_ga_y, float &mag_ga_z);
+	int process(const struct mag_data_packet &data, float &mag_ga_x, float &mag_ga_y, float &mag_ga_z);
 
 protected:
 	// @brief

--- a/drivers/ms5611/MS5611.cpp
+++ b/drivers/ms5611/MS5611.cpp
@@ -57,6 +57,16 @@ using namespace DriverFramework;
 
 #define POW2(_x) ((_x) * (_x))
 
+MS5611::MS5611(const char *device_path)
+	: BaroSensor(device_path, MS5611_MEASURE_INTERVAL_US / 2)
+	, m_temperature_from_sensor(0)
+	, m_pressure_from_sensor(0)
+	, m_measure_phase(0)
+{
+	m_id.dev_id_s.devtype = DRV_DF_DEVTYPE_MS5611;
+	m_id.dev_id_s.address = MS5611_SLAVE_ADDRESS;
+}
+
 // convertPressure must be called after convertTemperature
 // as convertTemperature sets m_raw_sensor_convertion values
 int64_t MS5611::convertPressure(int64_t adc_P)

--- a/drivers/ms5611/MS5611.hpp
+++ b/drivers/ms5611/MS5611.hpp
@@ -84,15 +84,7 @@ struct ms5611_sensor_measurement {
 class MS5611 : public BaroSensor
 {
 public:
-	MS5611(const char *device_path) :
-		BaroSensor(device_path, MS5611_MEASURE_INTERVAL_US / 2),
-		m_temperature_from_sensor(0),
-		m_pressure_from_sensor(0),
-		m_measure_phase(0)
-	{
-		m_id.dev_id_s.devtype = DRV_DF_DEVTYPE_MS5611;
-		m_id.dev_id_s.address = MS5611_SLAVE_ADDRESS;
-	}
+	MS5611(const char *device_path);
 
 	virtual ~MS5611() = default;
 

--- a/drivers/ms5611/MS5611.hpp
+++ b/drivers/ms5611/MS5611.hpp
@@ -63,9 +63,7 @@ struct ms5611_sensor_measurement {
 #define BARO_DEVICE_PATH "/dev/i2c-1"
 #endif
 
-// update frequency is 50 Hz (44.4-51.3Hz ) at 8x oversampling
-#define MS5611_MEASURE_INTERVAL_US 20000 // microseconds
-#define MS5611_CONVERSION_INTERVAL_US 10000 /*microseconds */
+#define MS5611_MEASURE_INTERVAL_US (20000)
 
 #define MS5611_BUS_FREQUENCY_IN_KHZ 400
 #define MS5611_TRANSFER_TIMEOUT_IN_USECS 9000
@@ -75,11 +73,7 @@ struct ms5611_sensor_measurement {
 
 #define DRV_DF_DEVTYPE_MS5611 0x45
 
-#define MS5611_SLAVE_ADDRESS 0x77       /* 7-bit slave address */
-
-#if MS5611_MEASURE_INTERVAL_US < (MS5611_CONVERSION_INTERVAL_US * 2)
-#error "MS5611_MEASURE_INTERVAL_US Must >= MS5611_CONVERSION_INTERVAL_US * 2"
-#endif
+#define MS5611_SLAVE_ADDRESS 0x77 /* 7-bit slave address */
 
 class MS5611 : public BaroSensor
 {
@@ -116,19 +110,19 @@ protected:
 
 	bool crc4(uint16_t *n_prom);
 
-	// returns 0 on success, -errno on failure
-	int ms5611_init();
-
 	// Send reset to device
 	int reset();
 
 	struct ms5611_sensor_calibration	m_sensor_calibration;
 	struct ms5611_sensor_measurement m_raw_sensor_convertion;
 
-	uint32_t m_temperature_from_sensor;
-	uint32_t m_pressure_from_sensor;
+private:
+	static void* threadFunc(void *arg);
 
-	int m_measure_phase;
+private:
+	pthread_t _thread_id;
+	bool _started;
+
 };
 
 }; // namespace DriverFramework

--- a/drivers/ms5611/MS5611.hpp
+++ b/drivers/ms5611/MS5611.hpp
@@ -65,15 +65,17 @@ struct ms5611_sensor_measurement {
 
 #define MS5611_MEASURE_INTERVAL_US (20000)
 
-#define MS5611_BUS_FREQUENCY_IN_KHZ 400
-#define MS5611_TRANSFER_TIMEOUT_IN_USECS 9000
+#define MS5611_SPI_FREQ_HZ (1000000)
+
+#define MS5611_I2C_FREQ_KHZ (400)
+#define MS5611_I2C_TIMEOUT_US (9000)
+#define MS5611_I2C_ADDR (0x77) /* 7-bit slave address */
 
 #define MS5611_MAX_LEN_SENSOR_DATA_BUFFER_IN_BYTES 6
 #define MS5611_MAX_LEN_CALIB_VALUES 16
 
 #define DRV_DF_DEVTYPE_MS5611 0x45
 
-#define MS5611_SLAVE_ADDRESS 0x77 /* 7-bit slave address */
 
 class MS5611 : public BaroSensor
 {

--- a/framework/include/ImuSensor.hpp
+++ b/framework/include/ImuSensor.hpp
@@ -99,6 +99,24 @@ struct imu_sensor_data {
 	bool		is_last_fifo_sample;
 };
 
+struct accel_data {
+	float accel_m_s2_x;
+	float accel_m_s2_y;
+	float accel_m_s2_z;
+};
+
+struct gyro_data {
+	float gyro_rad_s_x;
+	float gyro_rad_s_y;
+	float gyro_rad_s_z;
+};
+
+struct mag_data {
+	float mag_ga_x;
+	float mag_ga_y;
+	float mag_ga_z;
+};
+
 void printImuValues(struct imu_sensor_data &data);
 
 #if defined(__IMU_USE_I2C)

--- a/framework/src/SPIDevObj.cpp
+++ b/framework/src/SPIDevObj.cpp
@@ -369,10 +369,8 @@ int SPIDevObj::_bulkRead(uint8_t address, uint8_t *out_buffer, int length)
 
 	// automatic write buffer
 	uint8_t *write_buffer = (uint8_t *)alloca(transfer_bytes);
-	memset(write_buffer, 0, transfer_bytes);
 	// automatic read buffer
 	uint8_t *read_buffer = (uint8_t *)alloca(transfer_bytes);
-	memset(read_buffer, 0, transfer_bytes);
 
 	write_buffer[0] = address | DIR_READ; // read mode
 


### PR DESCRIPTION
Hello,

This is an attempt to optimize the existing driver. After cleaning it up a bit (make compatible with other Linux platforms), I plan to move it in PX4/Firmware in order to remove data members duplication and inability to use perf counters.

Highlights:
* stop using WorkQueues. Start a high priority thread for only this task.
* ability to pin the thread to a CPU Core. Together with pinning the SPIDev kernel workthread, this reduces the latency and jitter.
* separate accel/gyro/mag publishing. This will allow for different sampling rates for each.
* Sample FIFO at 18 MHz, the datasheet specifies the limit at 20 MHz +- 10%

I've tested sampling FIFO at 8 KHz, with gyro running at 8 KHz, accel at 4 KHz and mag at 100 Hz.
Unfortunately I couldn't achieve 8 KHz because the FIFO was too slow to sample the mag, this needs investigation/tuning the I2C delay registers. If I disable the mag, it runs at 8 KHz.