### PR TITLE
DevObj: don't force drivers to specify a callback period

### DIFF
--- a/framework/src/DevObj.cpp
+++ b/framework/src/DevObj.cpp
@@ -160,9 +160,8 @@ int DevObj::start()
 		return -2;
 	}
 
-	// Can't start if no interval specified
 	if (m_sample_interval_usecs == 0) {
-		return -3;
+		return 0;
 
 	} else {
 		do {
@@ -189,6 +188,9 @@ int DevObj::stop()
 
 	if (m_work_handle.isValid()) {
 		WorkMgr::releaseWorkHandle(m_work_handle);
+
+	} else if (m_sample_interval_usecs == 0) {
+		return 0;
 
 	} else {
 		// Driver wasn't running


### PR DESCRIPTION
Some drivers want to implement a custom callback scheme, hence
won't use the DevObj/WorkMgr for this.

Signed-off-by: Nicolae Rosia <nicolae.rosia@gmail.com>