### PR TITLE
Updates for OcPoC DF Stability

### DIFF
--- a/drivers/hmc5883/HMC5883.cpp
+++ b/drivers/hmc5883/HMC5883.cpp
@@ -121,6 +121,16 @@ int HMC5883::hmc5883_init()
 		return -EIO;
 	}
 
+#if defined(__DF_OCPOC)
+	// Set continuous measurement mode
+	uint8_t mode = HMC5883_BITS_CONFIG_A_CONTINUOUS_75HZ;
+	result = _writeReg(HMC5883_REG_MODE, &mode, sizeof(mode));
+
+	if (result != 0) {
+		DF_LOG_ERR("error: setting sensor mode failed");
+	}
+
+#endif
 
 	usleep(1000);
 	return 0;
@@ -131,7 +141,7 @@ int HMC5883::start()
 	int result = I2CDevObj::start();
 
 	if (result != 0) {
-		DF_LOG_ERR("error: could not start DevObj");
+		DF_LOG_ERR("error: could not start I2CDevObj");
 		goto exit;
 	}
 
@@ -215,7 +225,7 @@ void HMC5883::_measure()
 		}
 	}
 
-
+#if !defined(__DF_OCPOC)
 	/* Request next measurement. */
 	uint8_t mode = HMC5883_BITS_MODE_SINGLE_MODE;
 	result = _writeReg(HMC5883_REG_MODE, &mode, sizeof(mode));
@@ -225,5 +235,6 @@ void HMC5883::_measure()
 		DF_LOG_ERR("error: setting sensor mode failed");
 	}
 
+#endif
 	_measurement_requested = true;
 }

--- a/drivers/hmc5883/HMC5883.hpp
+++ b/drivers/hmc5883/HMC5883.hpp
@@ -43,8 +43,13 @@ namespace DriverFramework
 #define MAG_DEVICE_PATH "/dev/iic-2"
 #endif
 
+#if defined(__DF_OCPOC)
+// 75 Hz (max sample rate supported in Continuous Measurement mode)
+#define HMC5883_MEASURE_INTERVAL_US (1000000/75)
+#else
 // 150 Hz (supported in single measurment mode is up to 160 Hz
 #define HMC5883_MEASURE_INTERVAL_US (1000000/150)
+#endif
 
 // TODO: include some common header file (currently in drv_sensor.h).
 #define DRV_DF_DEVTYPE_HMC5883 0x43

--- a/drivers/ms5611/MS5611.cpp
+++ b/drivers/ms5611/MS5611.cpp
@@ -168,6 +168,14 @@ int MS5611::loadCalibration()
 		uint16_t w;
 	} cvt {};
 
+#if defined(__BARO_USE_SPI) && defined(__DF_OCPOC)
+
+	if (SPIDevObj::start() != 0) {
+		DF_LOG_ERR("error: could not start SPIDevObj");
+	}
+
+#endif
+
 	for (int i = 0; i < 8; ++i) {
 		uint8_t cmd = ADDR_PROM_SETUP + (i * 2);
 
@@ -196,6 +204,14 @@ int MS5611::loadCalibration()
 		cvt.b[1] = prom_buf[0];
 		memcpy(((uint16_t *)&m_sensor_calibration + i), &cvt.w, sizeof(uint16_t));
 	}
+
+#if defined(__BARO_USE_SPI) && defined(__DF_OCPOC)
+
+	if (SPIDevObj::stop() != 0) {
+		DF_LOG_ERR("error: could not stop SPIDevObj");
+	}
+
+#endif
 
 	DF_LOG_DEBUG("factory_setup: %d", m_sensor_calibration.factory_setup);
 	DF_LOG_DEBUG("c1: %d", m_sensor_calibration.c1_pressure_sens);
@@ -230,6 +246,14 @@ int MS5611::ms5611_init()
 		DF_LOG_ERR("could not set slave config");
 	}
 
+#if defined(__BARO_USE_SPI) && defined(__DF_OCPOC)
+
+	if (SPIDevObj::stop() != 0) {
+		DF_LOG_ERR("error: could not stop SPIDevObj");
+	}
+
+#endif
+
 	/* Reset sensor and load calibration data into internal register */
 	result = reset();
 
@@ -260,10 +284,25 @@ int MS5611::reset()
 	uint8_t cmd = ADDR_RESET_CMD;
 
 #if defined(__BARO_USE_SPI)
+#if defined(__DF_OCPOC)
+
+	if (SPIDevObj::start() != 0) {
+		DF_LOG_ERR("error: could not start SPIDevObj");
+	}
+
+#endif
+
 	uint8_t wbuf[1];
 	uint8_t rbuf[1];
 	wbuf[0] = cmd;
 	result = _transfer(wbuf, rbuf, 1);
+#if defined(__DF_OCPOC)
+
+	if (SPIDevObj::stop() != 0) {
+		DF_LOG_ERR("error: could not stop SPIDevObj");
+	}
+
+#endif
 
 #else
 
@@ -332,11 +371,26 @@ int MS5611::_request(uint8_t cmd)
 	int ret;
 
 #if defined(__BARO_USE_SPI)
+#if defined(__DF_OCPOC)
+
+	if (SPIDevObj::start() != 0) {
+		DF_LOG_ERR("error: could not start SPIDevObj");
+	}
+
+#endif
+
 	uint8_t wbuf[1];
 	uint8_t rbuf[1];
 
 	wbuf[0] = cmd;
 	ret = _transfer(wbuf, rbuf, 1);
+#if defined(__DF_OCPOC)
+
+	if (SPIDevObj::stop() != 0) {
+		DF_LOG_ERR("error: could not stop SPIDevObj");
+	}
+
+#endif
 #else
 	_retries = 0;
 	ret = _writeReg(cmd, nullptr, 0);
@@ -361,11 +415,26 @@ int MS5611::_collect(uint32_t &raw)
 	uint8_t cmd = ADDR_CMD_ADC_READ;
 
 #if defined(__BARO_USE_SPI)
+#if defined(__DF_OCPOC)
+
+	if (SPIDevObj::start() != 0) {
+		DF_LOG_ERR("error: could not start SPIDevObj");
+	}
+
+#endif
+
 	uint8_t buf[4];
 	uint8_t wbuf[4];
 	wbuf[0] = cmd;
 
 	ret = _transfer(&wbuf[0], &buf[0], 4);
+#if defined(__DF_OCPOC)
+
+	if (SPIDevObj::stop() != 0) {
+		DF_LOG_ERR("error: could not stop SPIDevObj");
+	}
+
+#endif
 
 	if (ret < 0) {
 		raw = 0;

--- a/framework/src/WorkItems.cpp
+++ b/framework/src/WorkItems.cpp
@@ -363,7 +363,7 @@ void WorkItems::_processExpiredWorkItems(uint64_t &next)
 
 // disable scheduling adjustment on embedded platforms (tests showed worse performance on RPI & QuRT with this)
 // see test results: https://github.com/PX4/DriverFramework/pull/155
-#if defined(__DF_LINUX) && !defined(__DF_RPI) && !defined(__DF_BEBOP) && !defined(__DF_EDISON)
+#if defined(__DF_LINUX) && !defined(__DF_RPI) && !defined(__DF_BEBOP) && !defined(__DF_EDISON) && !defined(__DF_OCPOC)
 
 	if (had_work) {
 		// Scheduling can have jitter, so adjust only by a fraction.


### PR DESCRIPTION
Our recent testing discovered some issues with DriverFramework on OcPoC hardware:

- The HMC5883 datasheet (pg. 12) recommends sampling at no more than 75 Hz in single measurement mode when not monitoring the DRDY interrupt pin, and in general there is no interrupt pin from the external HMC5883 normally packaged with many popular external GPS modules. On OcPoC hardware, there are also occasional glitches in the I2C line during the _measure() callback, and the subsequent write single-measurement setting would lock up the kernel just long enough to cause an Accel #0 TOUT! error. For this reason, we set the HMC5883 into continuous measurement mode during hmc5883_init() so we no longer have to continuously write the measurement mode after every read.

- As PR #155 disabled the scheduling adjustment for embedded platforms, we have now disabled that adjustment for OcPoC hardware as well.

- During testing, there seemed to be a memory leak which would cause all DriverFramework devices to fail simultaneously leading to uncontrolled flight. Upon stopping PX4 we would find that the SPI devices were sometimes still accessible from testing scripts, and the I2C devices would entirely segfault or return corrupted data. It’s suspected that when the bus drivers leave their file descriptors open they continually allocate memory until the devices are closed. It is a poor practice to leave device files open for the majority of the operation, as that ties up machine resources. Thus we have introduced opening and closing of the device files during normal I/O transactions, keeping in accordance with NASA’s ‘94 C-Style guide, Chapter 8.2 as “Free allocated memory as soon as possible”.

Note that we have kept all changes board-specific to OcPoC to avoid unnecessary changes or unintended consequences on other hardware, but these changes may be worthwhile to test for more generic implementation.