### PR TITLE
Fix MPU6050 on Bebop 2

### DIFF
--- a/framework/include/ImuSensor.hpp
+++ b/framework/include/ImuSensor.hpp
@@ -41,6 +41,8 @@
 
 #if defined(__DF_BBBLUE)
 #define IMU_DEVICE_PATH "/dev/i2c-2"
+#elif defined(__DF_BEBOP)
+#define IMU_DEVICE_PATH "/dev/i2c-mpu6050"
 #else
 #define IMU_DEVICE_PATH "/dev/iic-2"
 #endif


### PR DESCRIPTION
On PX4 master, the MPU6050 failed to initialize with the following error:
```
388329 Error: I2CDevObj::start failed on ::open() /dev/iic-2
388453 DevObj start failed
388507 Unable to open the device path: /dev/iic-2
ERROR [df_mpu6050_wrapper] MPU6050 start fail: -1
ERROR [df_mpu6050_wrapper] DfMPU6050Wrapper start failed
```

Now it is happy:
```
500159 IMU temperature initialized to: 52.085880
```