### PR TITLE
framework: forward time calls to PX4 if PX4 build

### DIFF
--- a/framework/src/DriverFramework.cpp
+++ b/framework/src/DriverFramework.cpp
@@ -34,7 +34,6 @@
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *************************************************************************/
 #include <stdio.h>
-#include <pthread.h>
 #include <errno.h>
 #include <time.h>
 #include "DriverFramework.hpp"

--- a/framework/src/SyncObj.cpp
+++ b/framework/src/SyncObj.cpp
@@ -38,6 +38,14 @@
 #include "DriverFramework.hpp"
 #include "SyncObj.hpp"
 
+#if defined(__PX4_POSIX) || defined(__PX4_QURT)
+#include <px4_time.h>
+#define df_pthread_cond_timedwait px4_pthread_cond_timedwait
+#else
+#include <pthread.h>
+#define df_pthread_cond_timedwait pthread_cond_timedwait
+#endif
+
 #define DEBUG(FMT, ...)
 //#define DEBUG(FMT, ...) printf(FMT, __VA_ARGS__)
 
@@ -88,7 +96,7 @@ int SyncObj::waitOnSignal(unsigned long timeout_us)
 	if (timeout_us) {
 		struct timespec ts {};
 		ret = absoluteTimeInFuture(timeout_us, ts);
-		ret = ret ? ret : pthread_cond_timedwait(&m_new_data_cond, &m_lock, &ts);
+		ret = ret ? ret : df_pthread_cond_timedwait(&m_new_data_cond, &m_lock, &ts);
 
 	} else {
 		ret = pthread_cond_wait(&m_new_data_cond, &m_lock);

--- a/framework/src/Time.cpp
+++ b/framework/src/Time.cpp
@@ -39,6 +39,10 @@
 #endif
 #include <time.h>
 
+#if defined(__PX4_POSIX) || defined(__PX4__QURT)
+#include <px4_time.h>
+#endif
+
 #if defined(__DF_APPLE_LEGACY)
 #include <sys/time.h>
 static int clock_gettime(int clk_id, struct timespec *t)
@@ -69,7 +73,11 @@ int DriverFramework::absoluteTime(struct timespec &ts)
 	// CLOCK_MONOTONIC not available on NuttX or OSX
 	return clock_gettime(0, &ts);
 #else
+#if defined(__PX4_POSIX) || defined(__PX4__QURT)
+	return px4_clock_gettime(CLOCK_MONOTONIC, &ts);
+#else
 	return clock_gettime(CLOCK_MONOTONIC, &ts);
+#endif
 #endif
 }
 


### PR DESCRIPTION
This adds some ifdefs to make sure that pthread_cond_timedwait is used
from the PX4 platform code if this happens to be a PX4 build.