### PR TITLE
framework: Attempt to check i2c-dev.h for sanity

### DIFF
--- a/framework/src/CMakeLists.txt
+++ b/framework/src/CMakeLists.txt
@@ -63,7 +63,7 @@ else()
 	if (COMMAND check_i2c_dev_h)
 		check_i2c_dev_h(I2C_DEV_H_HAS_I2C_MSG)
 		if (${I2C_DEV_H_HAS_I2C_MSG})
-			add_compile_definitions(df_driver_framework PRIVATE
+			target_compile_definitions(df_driver_framework PRIVATE
 					I2C_DEV_H_HAS_I2C_MSG
 					)
 		endif()

--- a/framework/src/CMakeLists.txt
+++ b/framework/src/CMakeLists.txt
@@ -59,6 +59,15 @@ else()
 		BaroSensor.cpp
 		MagSensor.cpp
 		)
+	# Try to check if i2c-dev.h is sane
+	if (COMMAND check_i2c_dev_h)
+		check_i2c_dev_h(I2C_DEV_H_HAS_I2C_MSG)
+		if (${I2C_DEV_H_HAS_I2C_MSG})
+			add_compile_definitions(df_driver_framework PRIVATE
+					I2C_DEV_H_HAS_I2C_MSG
+					)
+		endif()
+	endif()
 endif()
 
 # vim: set noet fenc=utf-8 ff=unix ft=cmake :

--- a/framework/src/I2CDevObj.cpp
+++ b/framework/src/I2CDevObj.cpp
@@ -47,7 +47,9 @@
 #elif defined(__DF_LINUX)
 #include <sys/ioctl.h>
 #include <linux/i2c-dev.h>
+#ifndef I2C_DEV_H_HAS_I2C_MSG
 #include <linux/i2c.h>
+#endif
 
 #ifdef __DF_BBBLUE
 #include <stdlib.h>


### PR DESCRIPTION
This is a part of a possible fix for
https://github.com/PX4/Firmware/issues/11137

This should not interfere with standalone builds of DriverFramework, but should
check whether i2c-dev.h file on a builder's system is sane when built as
a part of PX4 firmware.

Signed-off-by: sfalexrog <sfalexrog@gmail.com>