### PR TITLE
Fix missing symbol from librobotcontrol

### DIFF
--- a/framework/src/I2CDevObj.cpp
+++ b/framework/src/I2CDevObj.cpp
@@ -173,7 +173,7 @@ int I2CDevObj::_readReg(uint8_t address, uint8_t *out_buffer, size_t length)
 
 	ssize_t bytes_read = 0;
 
-	bytes_read = rc_i2c_read_data(m_bus_num, address, length, out_buffer);
+	bytes_read = rc_i2c_read_bytes(m_bus_num, address, length, out_buffer);
 
 	if (bytes_read != (ssize_t)length) {
 		DF_LOG_ERR("error: I2CDevObj::_readReg reports a read of %zd bytes at address 0x%X, but attempted to read %zd bytes",


### PR DESCRIPTION
Under several conditions it is possible to have this symbol in lib.
However by default it is not getting compiled. Also under the hood
function rc_i2c_read_data immediatelly calls rc_i2c_read_bytes.